### PR TITLE
Fix prometheus scraping port labels and allow overrides and disable

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "2.0.0"
+version: "2.0.1"
 appVersion: "23.11.1"
 keywords:
   - Webhooks

--- a/charts/ingest/templates/deployment.yaml
+++ b/charts/ingest/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "80"
+      {{- with .Values.app.podAnnotations }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
+      {{- end }}
         updatedAt: {{ now | quote }}
       labels:
         app.kubernetes.io/name: {{ include "convoy-ingest.name" . }}

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -13,6 +13,10 @@ app:
     requests:
       cpu: 400m
       memory: 500Mi
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.app.port }}"
 
 env:
   environment: ""

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "80"
+      {{- with .Values.app.podAnnotations }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
+      {{- end }}
         updatedAt: {{ now | quote }}
       labels:
         app.kubernetes.io/name: {{ include "convoy-server.name" . }}

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -12,6 +12,11 @@ app:
     requests:
       cpu: 40m
       memory: 50Mi
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.app.port }}"
+
 env:
   sign_up_enabled: false
   auth:

--- a/charts/stream/templates/deployment.yaml
+++ b/charts/stream/templates/deployment.yaml
@@ -17,9 +17,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "80"
+      {{- with .Values.app.podAnnotations }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
+      {{- end }}
         updatedAt: {{ now | quote }}
       labels:
         app.kubernetes.io/name: {{ include "convoy-stream.name" . }}

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -13,6 +13,10 @@ app:
     requests:
       cpu: 40m
       memory: 50Mi
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.app.port }}"
 
 env:
   environment: ""

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -16,9 +16,9 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
-        prometheus.io/port: "80"
+      {{- with .Values.app.podAnnotations }}
+        {{- tpl (toYaml . ) $ | nindent 8 }}
+      {{- end }}
         updatedAt: {{ now | quote }}
       labels:
         app.kubernetes.io/name: {{ include "convoy-worker.name" . }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -12,6 +12,10 @@ app:
     requests:
       cpu: 400m
       memory: 500Mi
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "{{ .Values.app.port }}"
 
 env:
   sign_up_enabled: false


### PR DESCRIPTION
This PR fixes wrong Prometheus port scraping (apps do use a configurable port, which actually a quick test show cannot be changed...) which is currently hardcoded to 80 and does not match current port.

Using values for this instead of hardcode it to right port will also allow disable scraping, I.E.:
```
worker:
  app:
    podAnnotations:
      prometheus.io/scrape: "false"
```