### PR TITLE
Helm chart improvements

### DIFF
--- a/charts/ingest/templates/deployment.yaml
+++ b/charts/ingest/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-migrate
-          image: bitnami/kubectl:1.24.4
+          image: bitnami/kubectl:1.24.10
           command:
             - /bin/sh
             - -c
@@ -156,4 +156,16 @@ spec:
             initialDelaySeconds: 30
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -53,3 +53,7 @@ autoscaling:
 podDisruptionBudget: {}
 #  maxUnavailable: 1
 #  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/migrate/templates/job.yaml
+++ b/charts/migrate/templates/job.yaml
@@ -96,3 +96,15 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.app.resources | nindent 16 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/migrate/values.yaml
+++ b/charts/migrate/values.yaml
@@ -23,3 +23,7 @@ fullNameOverride: "convoy-migrate"
 
 ingress:
   enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-migrate
-          image: bitnami/kubectl:1.24.4
+          image: bitnami/kubectl:1.24.10
           command:
             - /bin/sh
             - -c
@@ -194,3 +194,15 @@ spec:
             initialDelaySeconds: 30
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -62,7 +62,7 @@ service:
 
 ingress:
   enabled: false
-  annotations: []
+  annotations: {}
   ingressClassName: ""
   tls:
     - hosts:
@@ -86,3 +86,7 @@ autoscaling:
 podDisruptionBudget: {}
 #  maxUnavailable: 1
 #  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/stream/templates/deployment.yaml
+++ b/charts/stream/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-migrate
-          image: bitnami/kubectl:1.24.4
+          image: bitnami/kubectl:1.24.10
           command:
             - /bin/sh
             - -c
@@ -152,4 +152,16 @@ spec:
             initialDelaySeconds: 30
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/stream/templates/tests/test-connection.yaml
+++ b/charts/stream/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['{{ include "convoy-stream.fullname" . }}:{{ .Values.service.port }}/health']
   restartPolicy: Never
+{{- end }}

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -42,7 +42,7 @@ service:
 
 ingress:
   enabled: false
-  annotations: []
+  annotations: {}
   ingressClassName: ""
   tls:
     - hosts:
@@ -54,3 +54,7 @@ ingress:
         paths:
           - path: /
             pathType: Prefix
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-migrate
-          image: bitnami/kubectl:1.24.4
+          image: bitnami/kubectl:1.24.10
           command:
             - /bin/sh
             - -c
@@ -221,3 +221,15 @@ spec:
             initialDelaySeconds: 30
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -73,3 +73,7 @@ autoscaling:
 podDisruptionBudget: {}
 #  maxUnavailable: 1
 #  minAvailable: 1
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/values.yaml
+++ b/values.yaml
@@ -244,7 +244,7 @@ stream:
   ingress:
     # -- Enable ingress for the stream server
     enabled: false
-    annotations: [ ]
+    annotations: {}
     ingressClassName: ""
     tls:
       - hosts:
@@ -318,7 +318,7 @@ server:
   ingress:
     # -- Enable ingress for the server
     enabled: false
-    annotations: [ ]
+    annotations: {}
     ingressClassName: ""
     tls:
       - hosts:


### PR DESCRIPTION
This PR makes the following improvements to the Helm chart:
* `bitnami/kubectl` is updated to 1.24.10. This version has arm64 support.
* Added support for `nodeSelector`, `affinity` and `tolerations` to have more control on scheduling.
* Fixed default values for `ingress.annotations` (should be map, instead of the list). Wrong default was causing `cannot overwrite table with non table` warning with custom values file.
* `test-connection` for stream now runs only when stream component is enabled. 

Test plan:
* Used the following values file to test:
```
server:
  ingress:
    enabled: true
    ingressClassName: alb
    annotations:
      external-dns.alpha.kubernetes.io/cloudflare-proxied: 'true'
      alb.ingress.kubernetes.io/scheme: internet-facing
      alb.ingress.kubernetes.io/target-type: ip
      alb.ingress.kubernetes.io/backend-protocol: HTTP
      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
      alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
      alb.ingress.kubernetes.io/group.name: cluster
    tls: []
    hosts:
      - host: convoy.example.com
        http:
          paths:
            - path: /
              pathType: Prefix
  nodeSelector:
    kubernetes.io/arch: amd64

  tolerations:
    - key: "key1"
      operator: "Equal"
      value: "value1"
      effect: "NoSchedule"

  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                  - antarctica-east1
                  - antarctica-west1

ingest:
  nodeSelector:
    kubernetes.io/arch: amd64

  tolerations:
  - key: "key1"
    operator: "Equal"
    value: "value1"
    effect: "NoSchedule"

  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                  - antarctica-east1
                  - antarctica-west1
migrate:
  nodeSelector:
    kubernetes.io/arch: amd64

  tolerations:
  - key: "key1"
    operator: "Equal"
    value: "value1"
    effect: "NoSchedule"

  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                  - antarctica-east1
                  - antarctica-west1

stream:
  nodeSelector:
    kubernetes.io/arch: amd64

  tolerations:
  - key: "key1"
    operator: "Equal"
    value: "value1"
    effect: "NoSchedule"

  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                  - antarctica-east1
                  - antarctica-west1

worker:
  nodeSelector:
    kubernetes.io/arch: amd64

  tolerations:
  - key: "key1"
    operator: "Equal"
    value: "value1"
    effect: "NoSchedule"

  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: topology.kubernetes.io/zone
                operator: In
                values:
                  - antarctica-east1
                  - antarctica-west1
```
* Verified (visually) with `helm template -f ~/convoy/convoy-values.yaml convoy . -n convoy` 
* Verified with `helm template -f ~/convoy/convoy-values.yaml convoy . -n convoy | kubectl apply --dry-run=server -n convoy -f -`
* Deployed the same changes on our environment (with updated values file).