### PR TITLE
Add support for putting annotations on the migrate job

### DIFF
--- a/charts/migrate/templates/job.yaml
+++ b/charts/migrate/templates/job.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: {{ include "convoy-migrate.fullname" . }}
   annotations:
+    {{- toYaml .Values.jobAnnotations | nindent 4 }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/migrate/values.yaml
+++ b/charts/migrate/values.yaml
@@ -27,3 +27,5 @@ ingress:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+jobAnnotations: {}


### PR DESCRIPTION
This PR introduces the ability to add annotations to the `migrate` job within the Helm chart. The primary use-case for this change is to provide the flexibility to manage the execution phase of the migration job, such as specifying when it should run in the context of ArgoCD synchronization.

In the current setup, the other services within the chart do not complete their synchronization until the migration job has been executed. However, without the ability to add specific annotations, we cannot control when the migration job runs in relation to the synchronization of other services. This leads to a deadlock situation where the migration job is waiting for other services to sync, and vice versa.

By enabling annotations for the migration job, we can, for example, add the ArgoCD annotation `argocd.argoproj.io/hook: Sync` to instruct ArgoCD to execute this job during the synchronization phase. This would resolve the deadlock by ensuring that the migration job runs before the other services are synchronized.
