### PR TITLE
fix chart testing lint

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --validate-maintainers=false
+        run: ct lint --config ct.yaml --all
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+ct:
+	ct lint --config ct.yaml --all
+
+.PHONY: ct

--- a/charts/ingest/Chart.yaml
+++ b/charts/ingest/Chart.yaml
@@ -1,12 +1,6 @@
 apiVersion: v2
 name: ingest
 description: Convoy Ingest Chart
-
-
 type: application
-
-
 version: "1.0.0"
-
-
 appVersion: "v23.05.3"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+remote: origin
+chart-dirs:
+  - charts
+target-branch: main
+helm-extra-args: --timeout 8m
+check-version-increment: false
+validate-maintainers: false


### PR DESCRIPTION
```
change fixes ct lint.

ps: When this runs, the pipeline will definitely fail due to some lint errors. 
These errors can be fixed in another PR(s). One of which can be found here. (https://github.com/frain-dev/helm-charts/pull/21).
```