### PR TITLE
Don't force CPU limits

### DIFF
--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -8,7 +8,6 @@ app:
   port: 5009
   resources:
     limits:
-      cpu: 2000m
       memory: 2000Mi
     requests:
       cpu: 1000m

--- a/charts/migrate/values.yaml
+++ b/charts/migrate/values.yaml
@@ -7,7 +7,6 @@ app:
   port: 3000
   resources:
     limits:
-      cpu: 50m
       memory: 60Mi
     requests:
       cpu: 40m

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -7,7 +7,6 @@ app:
   port: 5005
   resources:
     limits:
-      cpu: 2000m
       memory: 2000Mi
     requests:
       cpu: 1000m

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -8,7 +8,6 @@ app:
   port: 5008
   resources:
     limits:
-      cpu: 50m
       memory: 60Mi
     requests:
       cpu: 40m

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -7,7 +7,6 @@ app:
   port: 5006
   resources:
     limits:
-      cpu: 2000m
       memory: 2000Mi
     requests:
       cpu: 1000m

--- a/values.yaml
+++ b/values.yaml
@@ -146,6 +146,15 @@ worker:
         region: ""
         session_token: ""
         endpoint: ""
+  app:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 2000Mi
+      requests:
+        cpu: 1000m
+        memory: 1000m
 
   service:
     # -- Type of service for the worker
@@ -188,6 +197,15 @@ ingest:
       license_key: *tracerLicenseKey
       config_enabled: *tracerConfigEnabled
       distributed_tracer_enabled: *tracerDistributedTracingEnabled
+  app:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 2000Mi
+      requests:
+        cpu: 1000m
+        memory: 1000Mi
 
   service:
     # -- Type of service for the worker
@@ -314,6 +332,15 @@ server:
         region: ""
         session_token: ""
         endpoint: ""
+  app:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 2000Mi
+      requests:
+        cpu: 1000m
+        memory: 1000Mi
 
   ingress:
     # -- Enable ingress for the server
@@ -359,3 +386,11 @@ migrate:
     pullPolicy: IfNotPresent
     # @ignored
     tag: *tag
+  app:
+    resources:
+      limits:
+        cpu: 50m
+        memory: 60Mi
+      requests:
+        cpu: 40m
+        memory: 50Mi


### PR DESCRIPTION
Hello !

CPU limits shouldn't be set by default on subcharts and users should be able to configure the pods without them.

Helm isn't able to nullify subcharts by-default values: https://github.com/helm/helm/pull/12879

This modification simply passes the default configuration of CPU and memory limits from the sub-charts to the main chart. I've kept the basic values as a recommendation, but the values are now nullifiable in a custom values.yaml:

```yaml
worker:
  app:
    resources:
      limits:
        cpu: null
        memory: 1500Mi
      requests:
        cpu: 50m
        memory: 100Mi
```