### PR TITLE
Remove reading jobAnnotations from values

### DIFF
--- a/charts/migrate/templates/job.yaml
+++ b/charts/migrate/templates/job.yaml
@@ -3,7 +3,6 @@ kind: Job
 metadata:
   name: {{ include "convoy-migrate.fullname" . }}
   annotations:
-    {{- toYaml .Values.jobAnnotations | nindent 4 }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
The installation fail if no value is set for "jobAnnotations" in the values.yaml file.
This commit removes the reading of the "jobAnnotations" from "convoy/charts/migrate/templates/job.yaml"
Fix issue: https://github.com/frain-dev/helm-charts/issues/24