### PR TITLE
OTeL and Sentry config

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 17.11.3
 digest: sha256:2c6ff47eb9a3976dbdb1a5b762cdc4343ef1846f63a8f00a612c9da0336602b5
-generated: "2023-06-05T14:49:57.883606542+01:00"
+generated: "2024-07-31T16:45:53.623284+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "2.4.0"
+version: "2.4.1"
 appVersion: "24.6.4"
 keywords:
   - Webhooks
@@ -17,9 +17,7 @@ dependencies:
     version: 12.5.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-
   - name: redis
     version: 17.11.3
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
-

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ Open Source Webhooks Gateway
 | global.convoy.image | string | `"docker.cloudsmith.io/convoy/convoy/frain-dev/convoy"` | Docker image tags for all convoy services |
 | global.convoy.log_level | string | `"error"` | Logger Level for all convoy services |
 | global.convoy.tag | string | `"v24.1.2"` | Docker image tags for all convoy services |
-| global.convoy.tracer_app_name | string | `""` | NewRelic application name |
-| global.convoy.tracer_config_enabled | bool | `true` | NewRelic tracing config enabled |
-| global.convoy.tracer_distributed_tracer_enabled | bool | `true` | NewRelic distributed tracing config enabled |
 | global.convoy.tracer_enabled | bool | `false` | Tracing config for all convoy services |
-| global.convoy.tracer_license_key | string | `""` | NewRelic license key |
 | global.convoy.tracer_type | string | `""` | Tracing provider type |
+| global.convoy.tracer_otel_sample_rate | float | `1.0` | OTel Sample rate |
+| global.convoy.tracer_otel_collector_url | string | `true` | OTel Collector url. Only grpc ingestion urls are supported |
+| global.convoy.tracer_otel_insecure_skip_verify | bool | `true` | Specifies if OTel collector server certs should be verified or not |
+| global.convoy.tracer_otel_auth_header_name | string | `""` | OTel Auth header name |
+| global.convoy.tracer_otel_auth_header_value | string | `""` | OTel Auth header value |
+| global.convoy.tracer_sentry_dsn | string | `""` | Sentry DSN |
 | global.externalDatabase.database | string | `"convoy"` | Database name for the external database |
 | global.externalDatabase.enabled | bool | `true` | Enable an external database, This will use postgresql chart, Change values if you use an external database |
 | global.externalDatabase.host | string | `"postgresql"` | Host for the external database |
@@ -175,12 +177,14 @@ Open Source Webhooks Gateway
 | worker.env.storage.s3.secretKey | string | `""` | Ignored in case of secret parameter with non-empty value |
 | worker.env.storage.s3.session_token | string | `""` |  |
 | worker.env.storage.type | string | `""` |  |
-| worker.env.tracer.app_name | string | `""` |  |
-| worker.env.tracer.config_enabled | bool | `true` |  |
-| worker.env.tracer.distributed_tracer_enabled | bool | `true` |  |
 | worker.env.tracer.enabled | bool | `false` |  |
-| worker.env.tracer.license_key | string | `""` |  |
-| worker.env.tracer.type | string | `""` |  |
+| worker.env.tracer.otel_sample_rate | float | `1.0` |  |
+| worker.env.tracer.otel_collector_url | string | `""` |  |
+| worker.env.tracer.otel_insecure_skip_verify | bool | `true` |  |
+| worker.env.tracer.otel_auth_header_name | string | `""` |  |
+| worker.env.tracer.otel_auth_header_value | string | `""` |  |
+| worker.env.tracer.sentry_dsn | string | `""` |
+| worker.extraEnvs | object | `{}` | Use this to inject extra ENVs. Check values.yaml to get a hint on object structure |
 | worker.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the worker image |
 | worker.image.repository | string | `"docker.cloudsmith.io/convoy/convoy/frain-dev/convoy"` | Repository to be used by the worker. The latest tag is used by default |
 | worker.podDisruptionBudget | object | `{}` |  |

--- a/charts/ingest/templates/deployment.yaml
+++ b/charts/ingest/templates/deployment.yaml
@@ -131,18 +131,34 @@ spec:
             {{- end }}
             {{- end }}
 
-            {{- if .Values.env.tracer.enabled }}
-            - name: CONVOY_NEWRELIC_APP_NAME
-              value: {{ .Values.env.tracer.app_name | quote }}
-            - name: CONVOY_NEWRELIC_LICENSE_KEY
-              value: {{ .Values.env.tracer.license_key | quote }}
-            - name: CONVOY_NEWRELIC_CONFIG_ENABLED
-              value: {{ .Values.env.tracer.config_enabled | quote }}
-            - name: CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED
-              value: {{ .Values.env.tracer.distributed_tracer_enabled | quote }}
+            {{- if and .Values.env.tracer.enabled }}
             - name: CONVOY_TRACER_PROVIDER
               value: {{ .Values.env.tracer.type | quote }}
+            {{- if eq (lower .Values.env.tracer.type) "otel" }}
+            - name: CONVOY_OTEL_SAMPLE_RATE
+              value: {{ .Values.env.tracer.otel_sample_rate | quote }}
+            - name: CONVOY_OTEL_COLLECTOR_URL
+              value: {{ .Values.env.tracer.otel_collector_url | quote }}
+            - name: CONVOY_OTEL_INSECURE_SKIP_VERIFY
+              value: {{ .Values.env.tracer.otel_insecure_skip_verify | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_NAME
+              value: {{ .Values.env.tracer.otel_auth_header_name | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_VALUE
+              value: {{ .Values.env.tracer.otel_auth_header_value | quote }}
             {{- end }}
+            {{- if eq (lower .Values.env.tracer.type) "sentry" }}
+            - name: CONVOY_SENTRY_DSN
+              value: {{ .Values.env.tracer.sentry_dsn | quote }}
+            {{- end }}
+            {{- end }}
+
+          {{- with .Values.extraEnvs }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              {{ if not (kindIs "map" $value) }}value: {{ tpl ( $value | quote ) $ }}{{ else }}
+              {{- tpl (toYaml $value) $ | nindent 14 | trim -}}{{- end -}}
+            {{- end }}
+          {{- end }}
 
           livenessProbe:
             httpGet:

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 enabled: true
+
 app:
   replicaCount: 1
   port: 5009
@@ -23,11 +24,26 @@ env:
   interval: 500
   tracer:
     enabled: false
-    app_name: ""
-    config_enabled: true
-    distributed_tracer_enabled: true
-    license_key: ""
-    type: ""
+    type: "otel"
+    otel_sample_rate: 1.0
+    otel_collector_url: ""
+    otel_insecure_skip_verify: true
+    otel_auth_header_name: ""
+    otel_auth_header_value: ""
+    sentry_dsn: ""
+
+extraEnvs: {}
+# Examples:
+  # ENV_NAME: value
+  # HOST_IP:
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.podIP
+  # SECRET_ENV:
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: thisissecretname
+  #      key: thisissecretkey
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -135,18 +135,34 @@ spec:
             {{- end }}
             {{- end }}
 
-            {{- if .Values.env.tracer.enabled }}
-            - name: CONVOY_NEWRELIC_APP_NAME
-              value: {{ .Values.env.tracer.app_name | quote }}
-            - name: CONVOY_NEWRELIC_LICENSE_KEY
-              value: {{ .Values.env.tracer.license_key | quote }}
-            - name: CONVOY_NEWRELIC_CONFIG_ENABLED
-              value: {{ .Values.env.tracer.config_enabled | quote }}
-            - name: CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED
-              value: {{ .Values.env.tracer.distributed_tracer_enabled | quote }}
+            {{- if and .Values.env.tracer.enabled }}
             - name: CONVOY_TRACER_PROVIDER
               value: {{ .Values.env.tracer.type | quote }}
+            {{- if eq (lower .Values.env.tracer.type) "otel" }}
+            - name: CONVOY_OTEL_SAMPLE_RATE
+              value: {{ .Values.env.tracer.otel_sample_rate | quote }}
+            - name: CONVOY_OTEL_COLLECTOR_URL
+              value: {{ .Values.env.tracer.otel_collector_url | quote }}
+            - name: CONVOY_OTEL_INSECURE_SKIP_VERIFY
+              value: {{ .Values.env.tracer.otel_insecure_skip_verify | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_NAME
+              value: {{ .Values.env.tracer.otel_auth_header_name | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_VALUE
+              value: {{ .Values.env.tracer.otel_auth_header_value | quote }}
             {{- end }}
+            {{- if eq (lower .Values.env.tracer.type) "sentry" }}
+            - name: CONVOY_SENTRY_DSN
+              value: {{ .Values.env.tracer.sentry_dsn | quote }}
+            {{- end }}
+            {{- end }}
+
+          {{- with .Values.extraEnvs }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              {{ if not (kindIs "map" $value) }}value: {{ tpl ( $value | quote ) $ }}{{ else }}
+              {{- tpl (toYaml $value) $ | nindent 14 | trim -}}{{- end -}}
+            {{- end }}
+          {{- end }}
 
             {{- if .Values.env.storage.enabled }}
             - name: CONVOY_STORAGE_POLICY_TYPE

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -29,11 +29,13 @@ env:
   host: ""
   tracer:
     enabled: false
-    app_name: ""
-    config_enabled: false
-    distributed_tracer_enabled: false
-    license_key: ""
-    type: ""
+    type: "otel"
+    otel_sample_rate: 1.0
+    otel_collector_url: ""
+    otel_insecure_skip_verify: true
+    otel_auth_header_name: ""
+    otel_auth_header_value: ""
+    sentry_dsn: ""
   storage:
     enabled: false
     type: ""
@@ -46,7 +48,18 @@ env:
       region: ""
       session_token: ""
       endpoint: ""
-
+extraEnvs: {}
+# Examples:
+  # ENV_NAME: value
+  # HOST_IP:
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.podIP
+  # SECRET_ENV:
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: thisissecretname
+  #      key: thisissecretkey
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/stream/templates/deployment.yaml
+++ b/charts/stream/templates/deployment.yaml
@@ -128,18 +128,35 @@ spec:
             {{- end }}
             {{- end }}
 
-            {{- if .Values.env.tracer.enabled }}
-            - name: CONVOY_NEWRELIC_APP_NAME
-              value: {{ .Values.env.tracer.app_name | quote }}
-            - name: CONVOY_NEWRELIC_LICENSE_KEY
-              value: {{ .Values.env.tracer.license_key | quote }}
-            - name: CONVOY_NEWRELIC_CONFIG_ENABLED
-              value: {{ .Values.env.tracer.config_enabled | quote }}
-            - name: CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED
-              value: {{ .Values.env.tracer.distributed_tracer_enabled | quote }}
+            {{- if and .Values.env.tracer.enabled }}
             - name: CONVOY_TRACER_PROVIDER
               value: {{ .Values.env.tracer.type | quote }}
+            {{- if eq (lower .Values.env.tracer.type) "otel" }}
+            - name: CONVOY_OTEL_SAMPLE_RATE
+              value: {{ .Values.env.tracer.otel_sample_rate | quote }}
+            - name: CONVOY_OTEL_COLLECTOR_URL
+              value: {{ .Values.env.tracer.otel_collector_url | quote }}
+            - name: CONVOY_OTEL_INSECURE_SKIP_VERIFY
+              value: {{ .Values.env.tracer.otel_insecure_skip_verify | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_NAME
+              value: {{ .Values.env.tracer.otel_auth_header_name | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_VALUE
+              value: {{ .Values.env.tracer.otel_auth_header_value | quote }}
             {{- end }}
+            {{- if eq (lower .Values.env.tracer.type) "sentry" }}
+            - name: CONVOY_SENTRY_DSN
+              value: {{ .Values.env.tracer.sentry_dsn | quote }}
+            {{- end }}
+            {{- end }}
+
+          {{- with .Values.extraEnvs }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              {{ if not (kindIs "map" $value) }}value: {{ tpl ( $value | quote ) $ }}{{ else }}
+              {{- tpl (toYaml $value) $ | nindent 14 | trim -}}{{- end -}}
+            {{- end }}
+          {{- end }}
+
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -20,12 +20,27 @@ app:
 env:
   environment: ""
   tracer:
-    enabled: true
-    app_name: ""
-    config_enabled: true
-    distributed_tracer_enabled: true
-    license_key: ""
-    type: ""
+    enabled: false
+    type: "otel"
+    otel_sample_rate: 1.0
+    otel_collector_url: ""
+    otel_insecure_skip_verify: true
+    otel_auth_header_name: ""
+    otel_auth_header_value: ""
+    sentry_dsn: ""
+
+extraEnvs: {}
+# Examples:
+  # ENV_NAME: value
+  # HOST_IP:
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.podIP
+  # SECRET_ENV:
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: thisissecretname
+  #      key: thisissecretkey
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -161,17 +161,25 @@ spec:
             {{- end }}
 
 
-            {{- if .Values.env.tracer.enabled }}
-            - name: CONVOY_NEWRELIC_APP_NAME
-              value: {{ .Values.env.tracer.app_name | quote }}
-            - name: CONVOY_NEWRELIC_LICENSE_KEY
-              value: {{ .Values.env.tracer.license_key | quote }}
-            - name: CONVOY_NEWRELIC_CONFIG_ENABLED
-              value: {{ .Values.env.tracer.config_enabled | quote }}
-            - name: CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED
-              value: {{ .Values.env.tracer.distributed_tracer_enabled | quote }}
+            {{- if and .Values.env.tracer.enabled }}
             - name: CONVOY_TRACER_PROVIDER
               value: {{ .Values.env.tracer.type | quote }}
+            {{- if eq (lower .Values.env.tracer.type) "otel" }}
+            - name: CONVOY_OTEL_SAMPLE_RATE
+              value: {{ .Values.env.tracer.otel_sample_rate | quote }}
+            - name: CONVOY_OTEL_COLLECTOR_URL
+              value: {{ .Values.env.tracer.otel_collector_url | quote }}
+            - name: CONVOY_OTEL_INSECURE_SKIP_VERIFY
+              value: {{ .Values.env.tracer.otel_insecure_skip_verify | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_NAME
+              value: {{ .Values.env.tracer.otel_auth_header_name | quote }}
+            - name: CONVOY_OTEL_AUTH_HEADER_VALUE
+              value: {{ .Values.env.tracer.otel_auth_header_value | quote }}
+            {{- end }}
+            {{- if eq (lower .Values.env.tracer.type) "sentry" }}
+            - name: CONVOY_SENTRY_DSN
+              value: {{ .Values.env.tracer.sentry_dsn | quote }}
+            {{- end }}
             {{- end }}
 
             {{- if .Values.env.storage.enabled }}
@@ -208,6 +216,13 @@ spec:
 
             {{- end }}
 
+          {{- with .Values.extraEnvs }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | quote }}
+              {{ if not (kindIs "map" $value) }}value: {{ tpl ( $value | quote ) $ }}{{ else }}
+              {{- tpl (toYaml $value) $ | nindent 14 | trim -}}{{- end -}}
+            {{- end }}
+          {{- end }}
 
           livenessProbe:
             httpGet:

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -31,11 +31,14 @@ env:
     username: ""
   tracer:
     enabled: false
-    app_name: ""
-    config_enabled: true
-    distributed_tracer_enabled: true
-    license_key: ""
-    type: ""
+    type: "otel"
+    otel_sample_rate: 1.0
+    otel_collector_url: ""
+    otel_insecure_skip_verify: true
+    otel_auth_header_name: ""
+    otel_auth_header_value: ""
+    sentry_dsn: ""
+
   storage:
     enabled: false
     type: ""
@@ -48,6 +51,19 @@ env:
       region: ""
       session_token: ""
       endpoint: ""
+
+extraEnvs: {}
+# Examples:
+  # ENV_NAME: value
+  # HOST_IP:
+  #  valueFrom:
+  #    fieldRef:
+  #      fieldPath: status.podIP
+  # SECRET_ENV:
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: thisissecretname
+  #      key: thisissecretkey
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,5 @@
-remote: origin
 chart-dirs:
   - charts
-target-branch: main
 helm-extra-args: --timeout 8m
 check-version-increment: false
 validate-maintainers: false

--- a/values.yaml
+++ b/values.yaml
@@ -10,16 +10,20 @@ global:
     environment: &environment "oss"
     # -- Tracing config for all convoy services
     tracer_enabled: &tracerEnabled false
-    # -- Tracing provider type
+    # -- Tracing provider type ["otel"|"sentry"]
     tracer_type: &tracerType ""
-    # -- NewRelic application name
-    tracer_app_name: &tracerAppName ""
-    # -- NewRelic tracing config enabled
-    tracer_config_enabled: &tracerConfigEnabled true
-    # -- NewRelic distributed tracing config enabled
-    tracer_distributed_tracer_enabled: &tracerDistributedTracingEnabled true
-    # -- NewRelic license key
-    tracer_license_key: &tracerLicenseKey ""
+    # -- OTel Sample rate
+    tracer_otel_sample_rate: &tracerOtelSampleRate 1.0
+    # -- OTel Collector url. Only grpc ingestion urls are supported.
+    tracer_otel_collector_url: &tracerOtelCollectorUrl ""
+    # -- Specifies if OTel collector server certs should be verified or not.
+    tracer_otel_insecure_skip_verify: &tracerOtelInsecureSkipVerify true
+    # -- OTel Auth header name
+    tracer_otel_auth_header_name: &tracerOtelAuthHeaderName ""
+    # -- OTel Auth header value
+    tracer_otel_auth_header_value: &tracerOtelAuthHeaderValue ""
+    # -- Sentry DSN
+    tracer_sentry_dsn: &tracerSentryDsn ""
 
   externalDatabase:
     # -- Enable an external database, This will use postgresql chart, Change values if you use an external database
@@ -125,12 +129,14 @@ worker:
       url: ""
       username: ""
     tracer:
-      type: *tracerType
       enabled: *tracerEnabled
-      app_name: *tracerAppName
-      license_key: *tracerLicenseKey
-      config_enabled: *tracerConfigEnabled
-      distributed_tracer_enabled: *tracerDistributedTracingEnabled
+      type: *tracerType
+      otel_sample_rate: *tracerOtelSampleRate
+      otel_collector_url: *tracerOtelCollectorUrl
+      otel_insecure_skip_verify: *tracerOtelInsecureSkipVerify
+      otel_auth_header_name: *tracerOtelAuthHeaderName
+      otel_auth_header_value: *tracerOtelAuthHeaderValue
+      sentry_dsn: *tracerSentryDsn
     storage:
       enabled: false
       type: ""
@@ -146,6 +152,18 @@ worker:
         region: ""
         session_token: ""
         endpoint: ""
+  extraEnvs: {}
+  # Examples:
+    # ENV_NAME: value
+    # HOST_IP:
+    #  valueFrom:
+    #    fieldRef:
+    #      fieldPath: status.podIP
+    # SECRET_ENV:
+    #  valueFrom:
+    #    secretKeyRef:
+    #      name: thisissecretname
+    #      key: thisissecretkey
   app:
     replicaCount: 1
     resources:
@@ -170,7 +188,7 @@ worker:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
     # -- Pod disruption budget
 #    maxUnavailable: 1
 #    minAvailable: 1
@@ -191,12 +209,26 @@ ingest:
     log_level: *logLevel
     # @ignored
     tracer:
-      type: *tracerType
       enabled: *tracerEnabled
-      app_name: *tracerAppName
-      license_key: *tracerLicenseKey
-      config_enabled: *tracerConfigEnabled
-      distributed_tracer_enabled: *tracerDistributedTracingEnabled
+      type: *tracerType
+      otel_sample_rate: *tracerOtelSampleRate
+      otel_collector_url: *tracerOtelCollectorUrl
+      otel_insecure_skip_verify: *tracerOtelInsecureSkipVerify
+      otel_auth_header_name: *tracerOtelAuthHeaderName
+      otel_auth_header_value: *tracerOtelAuthHeaderValue
+      sentry_dsn: *tracerSentryDsn
+  extraEnvs: {}
+  # Examples:
+    # ENV_NAME: value
+    # HOST_IP:
+    #  valueFrom:
+    #    fieldRef:
+    #      fieldPath: status.podIP
+    # SECRET_ENV:
+    #  valueFrom:
+    #    secretKeyRef:
+    #      name: thisissecretname
+    #      key: thisissecretkey
   app:
     replicaCount: 1
     resources:
@@ -221,12 +253,10 @@ ingest:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
   # -- Pod disruption budget
     #  maxUnavailable: 1
     #  minAvailable: 1
-
-
 
 stream:
   enabled: false
@@ -252,13 +282,26 @@ stream:
     environment: *environment
     # @ignored
     tracer:
-      type: *tracerType
       enabled: *tracerEnabled
-      app_name: *tracerAppName
-      license_key: *tracerLicenseKey
-      config_enabled: *tracerConfigEnabled
-      distributed_tracer_enabled: *tracerDistributedTracingEnabled
-
+      type: *tracerType
+      otel_sample_rate: *tracerOtelSampleRate
+      otel_collector_url: *tracerOtelCollectorUrl
+      otel_insecure_skip_verify: *tracerOtelInsecureSkipVerify
+      otel_auth_header_name: *tracerOtelAuthHeaderName
+      otel_auth_header_value: *tracerOtelAuthHeaderValue
+      sentry_dsn: *tracerSentryDsn
+  extraEnvs: {}
+  # Examples:
+    # ENV_NAME: value
+    # HOST_IP:
+    #  valueFrom:
+    #    fieldRef:
+    #      fieldPath: status.podIP
+    # SECRET_ENV:
+    #  valueFrom:
+    #    secretKeyRef:
+    #      name: thisissecretname
+    #      key: thisissecretkey
   ingress:
     # -- Enable ingress for the stream server
     enabled: false
@@ -313,12 +356,14 @@ server:
         enabled: true
     # @ignored
     tracer:
-      type: *tracerType
       enabled: *tracerEnabled
-      app_name: *tracerAppName
-      license_key: *tracerLicenseKey
-      config_enabled: *tracerConfigEnabled
-      distributed_tracer_enabled: *tracerDistributedTracingEnabled
+      type: *tracerType
+      otel_sample_rate: *tracerOtelSampleRate
+      otel_collector_url: *tracerOtelCollectorUrl
+      otel_insecure_skip_verify: *tracerOtelInsecureSkipVerify
+      otel_auth_header_name: *tracerOtelAuthHeaderName
+      otel_auth_header_value: *tracerOtelAuthHeaderValue
+      sentry_dsn: *tracerSentryDsn
     storage:
       enabled: false
       type: ""
@@ -334,6 +379,18 @@ server:
         region: ""
         session_token: ""
         endpoint: ""
+  extraEnvs: {}
+  # Examples:
+    # ENV_NAME: value
+    # HOST_IP:
+    #  valueFrom:
+    #    fieldRef:
+    #      fieldPath: status.podIP
+    # SECRET_ENV:
+    #  valueFrom:
+    #    secretKeyRef:
+    #      name: thisissecretname
+    #      key: thisissecretkey
   app:
     replicaCount: 1
     resources:
@@ -374,7 +431,7 @@ server:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
     # -- Pod disruption budget
 #    maxUnavailable: 1
 #    minAvailable: 1


### PR DESCRIPTION
This PR includes 3 changes:
- Allow OTeL and Sentry config, using documentation at `tracer` section at https://docs.getconvoy.io/deployment/configuration 
- Could not find anymore any reference of code related to NewRelic in tracing nor that documentation which seems like removed or it simply hasn't ever been there.
- Introduces a new value `extraEnvs` which among many other uses like inject ENV from values can be leveraged to extend OTeL config as documented at https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ 

Noticed problems in CI when testing charts. I am working on another PR to fix that but I prefer not to mix with this one as I am gonna need some changes which may break some retro-compatibility as dependencies do use `.Values.global.externalDatabase` & `.Values.global.externalRedis` which is are defined and among many other things like CT config that breaks LINT CI. Updates on that coming soon...
