### PR TITLE
lint CI fixes

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -2,6 +2,10 @@ name: Lint and Test Charts
 
 on: pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.1
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Add Bitnami Charts Repo
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -29,17 +33,18 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch release-0.8)
+          changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --all
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --config ct.yaml --charts .
+        if: steps.list-changed.outputs.changed == 'true'

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,9 +1,24 @@
 dependencies:
+- name: ingest
+  repository: ""
+  version: 1.0.0
+- name: migrate
+  repository: ""
+  version: 1.0.0
+- name: server
+  repository: ""
+  version: 1.0.0
+- name: stream
+  repository: ""
+  version: 1.0.0
+- name: worker
+  repository: ""
+  version: 1.0.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 12.5.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 17.11.3
-digest: sha256:2c6ff47eb9a3976dbdb1a5b762cdc4343ef1846f63a8f00a612c9da0336602b5
-generated: "2023-06-05T14:49:57.883606542+01:00"
+digest: sha256:f3088c52b8f8dfd4650bd8dcda138168f050a6edbc5195e94453d912ed00b2e8
+generated: "2024-07-31T17:04:22.026668+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "2.4.0"
+version: "2.5.0"
 appVersion: "24.6.4"
 keywords:
   - Webhooks
@@ -13,13 +13,21 @@ maintainers:
     email: engineering@getconvoy.io
     url: https://getconvoy.io
 dependencies:
+  - name: "ingest"
+    version: "1.0.0"
+  - name: "migrate"
+    version: "1.0.0"
+  - name: "server"
+    version: "1.0.0"
+  - name: "stream"
+    version: "1.0.0"
+  - name: "worker"
+    version: "1.0.0"
   - name: postgresql
     version: 12.5.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-
   - name: redis
     version: 17.11.3
     repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled
-
+    condition: redis.enabled3

--- a/charts/ingest/templates/deployment.yaml
+++ b/charts/ingest/templates/deployment.yaml
@@ -57,77 +57,77 @@ spec:
             - name: CONVOY_ENV
               value: {{ .Values.env.environment | quote }}
 
-            {{- if .Values.global.externalDatabase.enabled }}
+            {{- if .Values.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
-              value: {{ .Values.global.externalDatabase.scheme | quote }}
+              value: {{ .Values.externalDatabase.scheme | quote }}
             - name: CONVOY_DB_HOST
-              value: {{ .Values.global.externalDatabase.host | quote }}
+              value: {{ .Values.externalDatabase.host | quote }}
             - name: CONVOY_DB_PORT
-              value: {{ .Values.global.externalDatabase.port | quote }}
+              value: {{ .Values.externalDatabase.port | quote }}
             - name: CONVOY_DB_USERNAME
-              value: {{ .Values.global.externalDatabase.username | quote }}
-            {{- if ne .Values.global.externalDatabase.secret "" }}
+              value: {{ .Values.externalDatabase.username | quote }}
+            {{- if ne .Values.externalDatabase.secret "" }}
             - name: CONVOY_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalDatabase.secret }}"
+                  name: "{{ .Values.externalDatabase.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_DB_PASSWORD
-              value: {{ .Values.global.externalDatabase.password | quote }}
+              value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}
             - name: CONVOY_DB_DATABASE
-              value: {{ .Values.global.externalDatabase.database | quote }}
+              value: {{ .Values.externalDatabase.database | quote }}
             - name: CONVOY_DB_OPTIONS
-              value: {{ .Values.global.externalDatabase.options | quote }}
+              value: {{ .Values.externalDatabase.options | quote }}
             {{- end }}
 
-            {{- if .Values.global.nativeRedis.enabled }}
+            {{- if .Values.nativeRedis.enabled }}
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.nativeRedis.host | quote }}
-            {{- if ne .Values.global.nativeRedis.secret "" }}
+              value: {{ .Values.nativeRedis.host | quote }}
+            {{- if ne .Values.nativeRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.nativeRedis.secret }}"
+                  name: "{{ .Values.nativeRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.nativeRedis.password | quote }}
+              value: {{ .Values.nativeRedis.password | quote }}
             {{- end }}
             - name: CONVOY_REDIS_PORT
-              value: {{ .Values.global.nativeRedis.port | quote }}
+              value: {{ .Values.nativeRedis.port | quote }}
             - name : CONVOY_REDIS_TYPE
               value: "NATIVE"
             {{- end }}
 
-            {{- if .Values.global.externalRedis.enabled }}
-            {{- if .Values.global.externalRedis.addresses }}
+            {{- if .Values.externalRedis.enabled }}
+            {{- if .Values.externalRedis.addresses }}
             - name: CONVOY_REDIS_CLUSTER_ADDRESSES
-              value: {{ .Values.global.externalRedis.addresses | quote }}
+              value: {{ .Values.externalRedis.addresses | quote }}
             {{- else }}
             - name: CONVOY_REDIS_TYPE
               value: "EXTERNAL"
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.externalRedis.host | quote }}
-            {{- if ne .Values.global.externalRedis.secret "" }}
+              value: {{ .Values.externalRedis.host | quote }}
+            {{- if ne .Values.externalRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalRedis.secret }}"
+                  name: "{{ .Values.externalRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.externalRedis.password | quote }}
+              value: {{ .Values.externalRedis.password | quote }}
             {{- end }}
             - name : CONVOY_REDIS_PORT
-              value: {{ .Values.global.externalRedis.port | quote }}
+              value: {{ .Values.externalRedis.port | quote }}
             - name: CONVOY_REDIS_SCHEME
-              value: {{ .Values.global.externalRedis.scheme | quote }}
+              value: {{ .Values.externalRedis.scheme | quote }}
             - name : CONVOY_REDIS_USERNAME
-              value: {{ .Values.global.externalRedis.username | quote }}
+              value: {{ .Values.externalRedis.username | quote }}
             - name: CONVOY_REDIS_DATABASE
-              value: {{ .Values.global.externalRedis.database | quote }}
+              value: {{ .Values.externalRedis.database | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -3,6 +3,14 @@
 # Declare variables to be passed into your templates.
 
 enabled: true
+
+externalDatabase:
+  enabled: false
+nativeRedis:
+  enabled: false
+externalRedis:
+  enabled: false
+
 app:
   replicaCount: 1
   port: 5009

--- a/charts/migrate/templates/job.yaml
+++ b/charts/migrate/templates/job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: {{ include "convoy-migrate.fullname" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
   labels:
@@ -23,75 +23,75 @@ spec:
           command: ["/cmd"]
           args: ["migrate", "up"]
           env:
-           {{- if .Values.global.externalDatabase.enabled }}
+           {{- if .Values.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
-              value: {{ .Values.global.externalDatabase.scheme | quote }}
+              value: {{ .Values.externalDatabase.scheme | quote }}
             - name: CONVOY_DB_HOST
-              value: {{ .Values.global.externalDatabase.host | quote }}
+              value: {{ .Values.externalDatabase.host | quote }}
             - name: CONVOY_DB_PORT
-              value: {{ .Values.global.externalDatabase.port | quote }}
+              value: {{ .Values.externalDatabase.port | quote }}
             - name: CONVOY_DB_USERNAME
-              value: {{ .Values.global.externalDatabase.username | quote }}
-            {{- if ne .Values.global.externalDatabase.secret "" }}
+              value: {{ .Values.externalDatabase.username | quote }}
+            {{- if ne .Values.externalDatabase.secret "" }}
             - name: CONVOY_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalDatabase.secret }}"
+                  name: "{{ .Values.externalDatabase.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_DB_PASSWORD
-              value: {{ .Values.global.externalDatabase.password | quote }}
+              value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}
             - name: CONVOY_DB_DATABASE
-              value: {{ .Values.global.externalDatabase.database | quote }}
+              value: {{ .Values.externalDatabase.database | quote }}
             - name: CONVOY_DB_OPTIONS
-              value: {{ .Values.global.externalDatabase.options | quote }}
+              value: {{ .Values.externalDatabase.options | quote }}
             {{- end }}
-            {{- if .Values.global.nativeRedis.enabled }}
+            {{- if .Values.nativeRedis.enabled }}
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.nativeRedis.host | quote }}
-            {{- if ne .Values.global.nativeRedis.secret "" }}
+              value: {{ .Values.nativeRedis.host | quote }}
+            {{- if ne .Values.nativeRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.nativeRedis.secret }}"
+                  name: "{{ .Values.nativeRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.nativeRedis.password | quote }}
+              value: {{ .Values.nativeRedis.password | quote }}
             {{- end }}
             - name: CONVOY_REDIS_PORT
-              value: {{ .Values.global.nativeRedis.port | quote }}
+              value: {{ .Values.nativeRedis.port | quote }}
             - name: CONVOY_REDIS_TYPE
               value: "NATIVE"
             {{- end }}
-            {{- if .Values.global.externalRedis.enabled }}
-            {{- if .Values.global.externalRedis.addresses }}
+            {{- if .Values.externalRedis.enabled }}
+            {{- if .Values.externalRedis.addresses }}
             - name: CONVOY_REDIS_CLUSTER_ADDRESSES
-              value: {{ .Values.global.externalRedis.addresses | quote }}
+              value: {{ .Values.externalRedis.addresses | quote }}
             {{- else }}
             - name: CONVOY_REDIS_TYPE
               value: "EXTERNAL"
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.externalRedis.host | quote }}
-            {{- if ne .Values.global.externalRedis.secret "" }}
+              value: {{ .Values.externalRedis.host | quote }}
+            {{- if ne .Values.externalRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalRedis.secret }}"
+                  name: "{{ .Values.externalRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.externalRedis.password | quote }}
+              value: {{ .Values.externalRedis.password | quote }}
             {{- end }}
             - name : CONVOY_REDIS_PORT
-              value: {{ .Values.global.externalRedis.port | quote }}
+              value: {{ .Values.externalRedis.port | quote }}
             - name: CONVOY_REDIS_SCHEME
-              value: {{ .Values.global.externalRedis.scheme | quote }}
+              value: {{ .Values.externalRedis.scheme | quote }}
             - name : CONVOY_REDIS_USERNAME
-              value: {{ .Values.global.externalRedis.username | quote }}
+              value: {{ .Values.externalRedis.username | quote }}
             - name: CONVOY_REDIS_DATABASE
-              value: {{ .Values.global.externalRedis.database | quote }}
+              value: {{ .Values.externalRedis.database | quote }}
             {{- end }}
             {{- end }}
           resources:

--- a/charts/migrate/values.yaml
+++ b/charts/migrate/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+externalDatabase:
+  enabled: false
+nativeRedis:
+  enabled: false
+externalRedis:
+  enabled: false
+
 app:
   replicaCount: 1
   port: 3000

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -61,77 +61,77 @@ spec:
             - name: CONVOY_SIGNUP_ENABLED
               value: {{ .Values.env.sign_up_enabled | quote }}
 
-            {{- if .Values.global.externalDatabase.enabled }}
+            {{- if .Values.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
-              value: {{ .Values.global.externalDatabase.scheme | quote }}
+              value: {{ .Values.externalDatabase.scheme | quote }}
             - name: CONVOY_DB_HOST
-              value: {{ .Values.global.externalDatabase.host | quote }}
+              value: {{ .Values.externalDatabase.host | quote }}
             - name: CONVOY_DB_PORT
-              value: {{ .Values.global.externalDatabase.port | quote }}
+              value: {{ .Values.externalDatabase.port | quote }}
             - name: CONVOY_DB_USERNAME
-              value: {{ .Values.global.externalDatabase.username | quote }}
-            {{- if ne .Values.global.externalDatabase.secret "" }}
+              value: {{ .Values.externalDatabase.username | quote }}
+            {{- if ne .Values.externalDatabase.secret "" }}
             - name: CONVOY_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalDatabase.secret }}"
+                  name: "{{ .Values.externalDatabase.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_DB_PASSWORD
-              value: {{ .Values.global.externalDatabase.password | quote }}
+              value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}
             - name: CONVOY_DB_DATABASE
-              value: {{ .Values.global.externalDatabase.database | quote }}
+              value: {{ .Values.externalDatabase.database | quote }}
             - name: CONVOY_DB_OPTIONS
-              value: {{ .Values.global.externalDatabase.options | quote }}
+              value: {{ .Values.externalDatabase.options | quote }}
             {{- end }}
 
-            {{- if .Values.global.nativeRedis.enabled }}
+            {{- if .Values.nativeRedis.enabled }}
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.nativeRedis.host | quote }}
-            {{- if ne .Values.global.nativeRedis.secret "" }}
+              value: {{ .Values.nativeRedis.host | quote }}
+            {{- if ne .Values.nativeRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.nativeRedis.secret }}"
+                  name: "{{ .Values.nativeRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.nativeRedis.password | quote }}
+              value: {{ .Values.nativeRedis.password | quote }}
             {{- end }}
             - name: CONVOY_REDIS_PORT
-              value: {{ .Values.global.nativeRedis.port | quote }}
+              value: {{ .Values.nativeRedis.port | quote }}
             - name: CONVOY_REDIS_TYPE
               value: "NATIVE"
             {{- end }}
 
-            {{- if .Values.global.externalRedis.enabled }}
-            {{- if .Values.global.externalRedis.addresses }}
+            {{- if .Values.externalRedis.enabled }}
+            {{- if .Values.externalRedis.addresses }}
             - name: CONVOY_REDIS_CLUSTER_ADDRESSES
-              value: {{ .Values.global.externalRedis.addresses | quote }}
+              value: {{ .Values.externalRedis.addresses | quote }}
             {{- else }}
             - name: CONVOY_REDIS_TYPE
               value: "EXTERNAL"
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.externalRedis.host | quote }}
-            {{- if ne .Values.global.externalRedis.secret "" }}
+              value: {{ .Values.externalRedis.host | quote }}
+            {{- if ne .Values.externalRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalRedis.secret }}"
+                  name: "{{ .Values.externalRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.externalRedis.password | quote }}
+              value: {{ .Values.externalRedis.password | quote }}
             {{- end }}
             - name : CONVOY_REDIS_PORT
-              value: {{ .Values.global.externalRedis.port | quote }}
+              value: {{ .Values.externalRedis.port | quote }}
             - name: CONVOY_REDIS_SCHEME
-              value: {{ .Values.global.externalRedis.scheme | quote }}
+              value: {{ .Values.externalRedis.scheme | quote }}
             - name : CONVOY_REDIS_USERNAME
-              value: {{ .Values.global.externalRedis.username | quote }}
+              value: {{ .Values.externalRedis.username | quote }}
             - name: CONVOY_REDIS_DATABASE
-              value: {{ .Values.global.externalRedis.database | quote }}
+              value: {{ .Values.externalRedis.database | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+externalDatabase:
+  enabled: false
+nativeRedis:
+  enabled: false
+externalRedis:
+  enabled: false
+
 app:
   replicaCount: 1
   port: 5005

--- a/charts/stream/templates/deployment.yaml
+++ b/charts/stream/templates/deployment.yaml
@@ -54,77 +54,77 @@ spec:
             - name: CONVOY_ENV
               value: {{ .Values.env.environment | quote }}
 
-            {{- if .Values.global.externalDatabase.enabled }}
+            {{- if .Values.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
-              value: {{ .Values.global.externalDatabase.scheme | quote }}
+              value: {{ .Values.externalDatabase.scheme | quote }}
             - name: CONVOY_DB_HOST
-              value: {{ .Values.global.externalDatabase.host | quote }}
+              value: {{ .Values.externalDatabase.host | quote }}
             - name: CONVOY_DB_PORT
-              value: {{ .Values.global.externalDatabase.port | quote }}
+              value: {{ .Values.externalDatabase.port | quote }}
             - name: CONVOY_DB_USERNAME
-              value: {{ .Values.global.externalDatabase.username | quote }}
-            {{- if ne .Values.global.externalDatabase.secret "" }}
+              value: {{ .Values.externalDatabase.username | quote }}
+            {{- if ne .Values.externalDatabase.secret "" }}
             - name: CONVOY_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalDatabase.secret }}"
+                  name: "{{ .Values.externalDatabase.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_DB_PASSWORD
-              value: {{ .Values.global.externalDatabase.password | quote }}
+              value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}
             - name: CONVOY_DB_DATABASE
-              value: {{ .Values.global.externalDatabase.database | quote }}
+              value: {{ .Values.externalDatabase.database | quote }}
             - name: CONVOY_DB_OPTIONS
-              value: {{ .Values.global.externalDatabase.options | quote }}
+              value: {{ .Values.externalDatabase.options | quote }}
             {{- end }}
 
-            {{- if .Values.global.nativeRedis.enabled }}
+            {{- if .Values.nativeRedis.enabled }}
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.nativeRedis.host | quote }}
-            {{- if ne .Values.global.nativeRedis.secret "" }}
+              value: {{ .Values.nativeRedis.host | quote }}
+            {{- if ne .Values.nativeRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.nativeRedis.secret }}"
+                  name: "{{ .Values.nativeRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.nativeRedis.password | quote }}
+              value: {{ .Values.nativeRedis.password | quote }}
             {{- end }}
             - name: CONVOY_REDIS_PORT
-              value: {{ .Values.global.nativeRedis.port | quote }}
+              value: {{ .Values.nativeRedis.port | quote }}
             - name: CONVOY_REDIS_TYPE
               value: "NATIVE"
             {{- end }}
 
-            {{- if .Values.global.externalRedis.enabled }}
-            {{- if .Values.global.externalRedis.addresses }}
+            {{- if .Values.externalRedis.enabled }}
+            {{- if .Values.externalRedis.addresses }}
             - name: CONVOY_REDIS_CLUSTER_ADDRESSES
-              value: {{ .Values.global.externalRedis.addresses | quote }}
+              value: {{ .Values.externalRedis.addresses | quote }}
             {{- else }}
             - name: CONVOY_REDIS_TYPE
               value: "EXTERNAL"
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.externalRedis.host | quote }}
-            {{- if ne .Values.global.externalRedis.secret "" }}
+              value: {{ .Values.externalRedis.host | quote }}
+            {{- if ne .Values.externalRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalRedis.secret }}"
+                  name: "{{ .Values.externalRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.externalRedis.password | quote }}
+              value: {{ .Values.externalRedis.password | quote }}
             {{- end }}
             - name : CONVOY_REDIS_PORT
-              value: {{ .Values.global.externalRedis.port | quote }}
+              value: {{ .Values.externalRedis.port | quote }}
             - name: CONVOY_REDIS_SCHEME
-              value: {{ .Values.global.externalRedis.scheme | quote }}
+              value: {{ .Values.externalRedis.scheme | quote }}
             - name : CONVOY_REDIS_USERNAME
-              value: {{ .Values.global.externalRedis.username | quote }}
+              value: {{ .Values.externalRedis.username | quote }}
             - name: CONVOY_REDIS_DATABASE
-              value: {{ .Values.global.externalRedis.database | quote }}
+              value: {{ .Values.externalRedis.database | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+externalDatabase:
+  enabled: false
+nativeRedis:
+  enabled: false
+externalRedis:
+  enabled: false
+
 enabled: true
 app:
   replicaCount: 1

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -61,77 +61,77 @@ spec:
               value: {{ .Values.env.sign_up_enabled | quote }}
 
 
-            {{- if .Values.global.externalDatabase.enabled }}
+            {{- if .Values.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
-              value: {{ .Values.global.externalDatabase.scheme | quote }}
+              value: {{ .Values.externalDatabase.scheme | quote }}
             - name: CONVOY_DB_HOST
-              value: {{ .Values.global.externalDatabase.host | quote }}
+              value: {{ .Values.externalDatabase.host | quote }}
             - name: CONVOY_DB_PORT
-              value: {{ .Values.global.externalDatabase.port | quote }}
+              value: {{ .Values.externalDatabase.port | quote }}
             - name: CONVOY_DB_USERNAME
-              value: {{ .Values.global.externalDatabase.username | quote }}
-            {{- if ne .Values.global.externalDatabase.secret "" }}
+              value: {{ .Values.externalDatabase.username | quote }}
+            {{- if ne .Values.externalDatabase.secret "" }}
             - name: CONVOY_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalDatabase.secret }}"
+                  name: "{{ .Values.externalDatabase.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_DB_PASSWORD
-              value: {{ .Values.global.externalDatabase.password | quote }}
+              value: {{ .Values.externalDatabase.password | quote }}
             {{- end }}
             - name: CONVOY_DB_DATABASE
-              value: {{ .Values.global.externalDatabase.database | quote }}
+              value: {{ .Values.externalDatabase.database | quote }}
             - name: CONVOY_DB_OPTIONS
-              value: {{ .Values.global.externalDatabase.options | quote }}
+              value: {{ .Values.externalDatabase.options | quote }}
             {{- end }}
 
-            {{- if .Values.global.nativeRedis.enabled }}
+            {{- if .Values.nativeRedis.enabled }}
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.nativeRedis.host | quote }}
-            {{- if ne .Values.global.nativeRedis.secret "" }}
+              value: {{ .Values.nativeRedis.host | quote }}
+            {{- if ne .Values.nativeRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.nativeRedis.secret }}"
+                  name: "{{ .Values.nativeRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.nativeRedis.password | quote }}
+              value: {{ .Values.nativeRedis.password | quote }}
             {{- end }}
             - name: CONVOY_REDIS_PORT
-              value: {{ .Values.global.nativeRedis.port | quote }}
+              value: {{ .Values.nativeRedis.port | quote }}
             - name : CONVOY_REDIS_TYPE
               value: "NATIVE"
             {{- end }}
 
-            {{- if .Values.global.externalRedis.enabled }}
-            {{- if .Values.global.externalRedis.addresses }}
+            {{- if .Values.externalRedis.enabled }}
+            {{- if .Values.externalRedis.addresses }}
             - name: CONVOY_REDIS_CLUSTER_ADDRESSES
-              value: {{ .Values.global.externalRedis.addresses | quote }}
+              value: {{ .Values.externalRedis.addresses | quote }}
             {{- else }}
             - name: CONVOY_REDIS_TYPE
               value: "EXTERNAL"
             - name: CONVOY_REDIS_HOST
-              value: {{ .Values.global.externalRedis.host | quote }}
-            {{- if ne .Values.global.externalRedis.secret "" }}
+              value: {{ .Values.externalRedis.host | quote }}
+            {{- if ne .Values.externalRedis.secret "" }}
             - name: CONVOY_REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: "{{ .Values.global.externalRedis.secret }}"
+                  name: "{{ .Values.externalRedis.secret }}"
                   key: password
             {{- else }}
             - name: CONVOY_REDIS_PASSWORD
-              value: {{ .Values.global.externalRedis.password | quote }}
+              value: {{ .Values.externalRedis.password | quote }}
             {{- end }}
             - name : CONVOY_REDIS_PORT
-              value: {{ .Values.global.externalRedis.port | quote }}
+              value: {{ .Values.externalRedis.port | quote }}
             - name: CONVOY_REDIS_SCHEME
-              value: {{ .Values.global.externalRedis.scheme | quote }}
+              value: {{ .Values.externalRedis.scheme | quote }}
             - name : CONVOY_REDIS_USERNAME
-              value: {{ .Values.global.externalRedis.username | quote }}
+              value: {{ .Values.externalRedis.username | quote }}
             - name: CONVOY_REDIS_DATABASE
-              value: {{ .Values.global.externalRedis.database | quote }}
+              value: {{ .Values.externalRedis.database | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -2,6 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+externalDatabase:
+  enabled: false
+nativeRedis:
+  enabled: false
+externalRedis:
+  enabled: false
+
 app:
   replicaCount: 1
   port: 5006

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,12 @@
-remote: origin
-chart-dirs:
-  - charts
+charts:
+  - .
+  - charts/ingest
+  - charts/migrate
+  - charts/server
+  - charts/stream
+  - charts/worker
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
 target-branch: main
 helm-extra-args: --timeout 8m
 check-version-increment: false

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ global:
     # -- NewRelic license key
     tracer_license_key: &tracerLicenseKey ""
 
-  externalDatabase:
+  externalDatabase: &externalDatabase
     # -- Enable an external database, This will use postgresql chart, Change values if you use an external database
     enabled: true
     # -- Host for the external database
@@ -43,7 +43,7 @@ global:
     # -- Port for the external database
     port: 5432
 
-  nativeRedis:
+  nativeRedis: &nativeRedis
     # -- Enable redis, This will use redis chart, Disable if you use an external redis
     enabled: &redisEnabled true
     # -- Host for the redis
@@ -55,7 +55,7 @@ global:
     # -- Port for the redis
     port: 6379
 
-  externalRedis:
+  externalRedis: &externalRedis
     # -- Enable external redis, Enable this if you use an external redis and disable Native redis
     enabled: false
     # -- redis cluster addresses, if set the other values won't be used
@@ -75,7 +75,6 @@ global:
     # -- Port for the external redis
     port: ""
 
-
 # @ignored, used in case of external chart
 postgresql:
   # -- Set to false if you don't want to create a postgres instance
@@ -89,7 +88,6 @@ postgresql:
         password: *userPassword
         database: *postgresDatabase
 
-
 # @ignored, used in case of external chart
 redis:
   # -- Set to false if you don't want to create a redis instance
@@ -101,6 +99,10 @@ redis:
     password: *redisPassword
 
 worker:
+  externalDatabase: *externalDatabase
+  nativeRedis: *nativeRedis
+  externalRedis: *externalRedis
+
   image:
     # -- Repository to be used by the worker. The latest tag is used by default
     repository: *image
@@ -170,13 +172,18 @@ worker:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
     # -- Pod disruption budget
 #    maxUnavailable: 1
 #    minAvailable: 1
 
 ingest:
   enabled: false
+
+  externalDatabase: *externalDatabase
+  nativeRedis: *nativeRedis
+  externalRedis: *externalRedis
+
   image:
     # -- Repository to be used by the worker. The latest tag is used by default
     repository: *image
@@ -221,15 +228,18 @@ ingest:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
   # -- Pod disruption budget
     #  maxUnavailable: 1
     #  minAvailable: 1
 
-
-
 stream:
   enabled: false
+
+  externalDatabase: *externalDatabase
+  nativeRedis: *nativeRedis
+  externalRedis: *externalRedis
+
   image:
     # -- Repository to be used by the stream. The latest tag is used by default
     repository: *image
@@ -291,6 +301,10 @@ stream:
 
 
 server:
+  externalDatabase: *externalDatabase
+  nativeRedis: *nativeRedis
+  externalRedis: *externalRedis
+
   image:
     # -- Repository to be used by the server. The latest tag is used by default
     repository: *image
@@ -374,13 +388,16 @@ server:
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
 
-  podDisruptionBudget: { }
+  podDisruptionBudget: {}
     # -- Pod disruption budget
 #    maxUnavailable: 1
 #    minAvailable: 1
 
-
 migrate:
+  externalDatabase: *externalDatabase
+  nativeRedis: *nativeRedis
+  externalRedis: *externalRedis
+
   image:
     # -- Repository to be used by to migrate. The latest tag is used by default. It will install before any other services.
     repository: *image


### PR DESCRIPTION
* Fixes chart-testing config by using `charts` list instead of `chart-dirs` so convoy Chart is also linted.
* Fixes subcharts usage of `.Values.global.` keys that are not present in there but in convoy Helm Chart instead
* Some other fixes for lint errors
* Adds Github config to avoid concurrent actions running per PR

Unfortunately chart testing via `ct install` won't ever work because server and worker do wait for migrate which is set as a post-install hook, so only way to install this chart is to disable server and worker (scale to 0) then install and it will runs migrate for the first time, then you can scale server and worker back to desired value.
We can use chart-testing to simulate first part of this scenario with:
1- `ct install --config ct.yaml --charts . --helm-extra-set-args "--set=server.app.replicaCount=0 --set=worker.app.replicaCount=0 --set=ingest.enabled=false"`
2- We will need to disable tests with something like `{{- if and .Values.enabled (gt .Values.app.replicaCount 0) -}}` 
But we won't be actually testing much, so `ct install` is not useful anymore.

This is not actually a CI issue but a design problem of Convoy chart, I have faced this same problem every time I have installed it.


