### PR TITLE
Allow usage analytics disable

### DIFF
--- a/charts/ingest/templates/deployment.yaml
+++ b/charts/ingest/templates/deployment.yaml
@@ -47,7 +47,6 @@ spec:
               containerPort: {{ .Values.app.port }}
               protocol: TCP
           env:
-
             - name: SERVICE_NAME
               value: {{ .Chart.Name }}
             - name: PORT
@@ -56,6 +55,9 @@ spec:
               value: {{ .Values.env.log_level | quote }}
             - name: CONVOY_ENV
               value: {{ .Values.env.environment | quote }}
+
+            - name: CONVOY_ANALYTICS_ENABLED
+              value: {{ .Values.env.analytics | quote }}
 
             {{- if .Values.global.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -29,7 +29,6 @@ env:
     distributed_tracer_enabled: true
     license_key: ""
     type: ""
-  analytics: true
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/ingest/values.yaml
+++ b/charts/ingest/values.yaml
@@ -21,6 +21,7 @@ env:
   environment: ""
   log_level: "error"
   interval: 500
+  analytics: true
   tracer:
     enabled: false
     app_name: ""
@@ -28,6 +29,7 @@ env:
     distributed_tracer_enabled: true
     license_key: ""
     type: ""
+  analytics: true
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             - name: CONVOY_SIGNUP_ENABLED
               value: {{ .Values.env.sign_up_enabled | quote }}
 
+            - name: CONVOY_ANALYTICS_ENABLED
+              value: {{ .Values.env.analytics | quote }}
+
             {{- if .Values.global.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
               value: {{ .Values.global.externalDatabase.scheme | quote }}

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -27,6 +27,7 @@ env:
   max_response_size: 50
   environment: ""
   host: ""
+  analytics: true
   tracer:
     enabled: false
     app_name: ""
@@ -46,7 +47,6 @@ env:
       region: ""
       session_token: ""
       endpoint: ""
-
 
 image:
   repository: docker.cloudsmith.io/convoy/convoy/frain-dev/convoy

--- a/charts/stream/templates/deployment.yaml
+++ b/charts/stream/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
             - name: CONVOY_ENV
               value: {{ .Values.env.environment | quote }}
 
+            - name: CONVOY_ANALYTICS_ENABLED
+              value: {{ .Values.env.analytics | quote }}
+
             {{- if .Values.global.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME
               value: {{ .Values.global.externalDatabase.scheme | quote }}

--- a/charts/stream/values.yaml
+++ b/charts/stream/values.yaml
@@ -19,6 +19,7 @@ app:
 
 env:
   environment: ""
+  analytics: true
   tracer:
     enabled: true
     app_name: ""

--- a/charts/worker/templates/deployment.yaml
+++ b/charts/worker/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
             - name: CONVOY_SIGNUP_ENABLED
               value: {{ .Values.env.sign_up_enabled | quote }}
 
+            - name: CONVOY_ANALYTICS_ENABLED
+              value: {{ .Values.env.analytics | quote }}
 
             {{- if .Values.global.externalDatabase.enabled }}
             - name: CONVOY_DB_SCHEME

--- a/charts/worker/values.yaml
+++ b/charts/worker/values.yaml
@@ -29,6 +29,7 @@ env:
     provider: ""
     url: ""
     username: ""
+  analytics: true
   tracer:
     enabled: false
     app_name: ""

--- a/values.yaml
+++ b/values.yaml
@@ -20,6 +20,8 @@ global:
     tracer_distributed_tracer_enabled: &tracerDistributedTracingEnabled true
     # -- NewRelic license key
     tracer_license_key: &tracerLicenseKey ""
+    # -- Enable usage analytics
+    analytics: &analytics true
 
   externalDatabase:
     # -- Enable an external database, This will use postgresql chart, Change values if you use an external database
@@ -146,6 +148,7 @@ worker:
         region: ""
         session_token: ""
         endpoint: ""
+    analytics: *&analytics
   app:
     replicaCount: 1
     resources:
@@ -197,6 +200,7 @@ ingest:
       license_key: *tracerLicenseKey
       config_enabled: *tracerConfigEnabled
       distributed_tracer_enabled: *tracerDistributedTracingEnabled
+    analytics: *&analytics
   app:
     replicaCount: 1
     resources:
@@ -258,6 +262,7 @@ stream:
       license_key: *tracerLicenseKey
       config_enabled: *tracerConfigEnabled
       distributed_tracer_enabled: *tracerDistributedTracingEnabled
+    analytics: *&analytics
 
   ingress:
     # -- Enable ingress for the stream server
@@ -334,6 +339,8 @@ server:
         region: ""
         session_token: ""
         endpoint: ""
+    analytics: *&analytics
+
   app:
     replicaCount: 1
     resources:


### PR DESCRIPTION
This will let enabled usage analytics by default. More info: https://docs.getconvoy.io/resources/telemetry 

But in some enterprise environment it is not acceptable to not have a quick and easy way to disable this, it is already available to Convoy but not in this Helm Chart yet.