### PR TITLE
Enable reading job annotations for the migrate job again

### DIFF
--- a/charts/migrate/templates/job.yaml
+++ b/charts/migrate/templates/job.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: {{ include "convoy-migrate.fullname" . }}
   annotations:
+    {{- toYaml .Values.jobAnnotations | nindent 4 }}
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/values.yaml
+++ b/values.yaml
@@ -381,6 +381,7 @@ server:
 
 
 migrate:
+  jobAnnotations: {}
   image:
     # -- Repository to be used by to migrate. The latest tag is used by default. It will install before any other services.
     repository: *image


### PR DESCRIPTION
Re-enables reading the job annotations for the migrate job, which were removed to solve this issue: https://github.com/frain-dev/helm-charts/issues/24

I think the above issue will be solved by this PR as well, since we are now setting a default empty `jobAnnotations` object in the global `values.yaml`