### PR TITLE
Update Convoy Helm chart to v3.7.0 with v25.9.2 support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "3.6.2"
-appVersion: "25.6.7"
+version: "3.7.0"
+appVersion: "25.9.2"
 keywords:
   - Webhooks
   - Kubernetes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # convoy
 
-![Version: 3.6.2](https://img.shields.io/badge/Version-3.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.6.7](https://img.shields.io/badge/AppVersion-25.6.7-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.9.2](https://img.shields.io/badge/AppVersion-25.9.2-informational?style=flat-square)
 
 Open Source Webhooks Gateway
 
@@ -85,6 +85,9 @@ Open Source Webhooks Gateway
 | global.convoy.cacert_secret_name | string | `""` | Dispatcher CA Certificate configuration. If provided, it will use the content of the secret |
 | global.convoy.enable_usage_analytics | bool | `true` | Enable usage analytics |
 | global.convoy.environment | string | `"oss"` | Convoy Environment |
+| global.convoy.google_oauth_client_id | string | `""` | Google OAuth Client ID from Google Cloud Console |
+| global.convoy.google_oauth_enabled | bool | `false` | Enable Google OAuth SSO for user authentication |
+| global.convoy.google_oauth_redirect_url | string | `""` | Google OAuth Redirect URL for callback handling |
 | global.convoy.image | string | `"getconvoy/convoy"` | Docker image tags for all convoy components |
 | global.convoy.jwt_refresh_secret | string | `"convoy-refresh-secret"` | JWT Refresh Secret key |
 | global.convoy.jwt_secret | string | `"convoy-secret"` | JWT Secret key |
@@ -97,10 +100,13 @@ Open Source Webhooks Gateway
 | global.convoy.otel_collector_url | string | `""` | Open Telemetry collector url |
 | global.convoy.otel_insecure_skip_verify | bool | `true` | Open Telemetry insecure skip verify |
 | global.convoy.otel_sample_rate | int | `1` | Open Telemetry sample rate |
+| global.convoy.portal_realm_enabled | bool | `false` | Enable Portal Realm authentication for enhanced security |
+| global.convoy.read_replica_dsn | string | `""` | Database read replica DSN for improved performance |
 | global.convoy.retention_policy_duration | string | `"720h"` | Retention policy duration |
 | global.convoy.retention_policy_enabled | bool | `false` | Retention policy enabled |
 | global.convoy.sentry_dsn | string | `""` | Sentry DSN |
-| global.convoy.tag | string | `"v25.6.7"` | Docker image tags for all convoy components |
+| global.convoy.sentry_sample_rate | float | `1` | Sentry sample rate for error sampling (0.0 to 1.0) |
+| global.convoy.tag | string | `"v25.9.2"` | Docker image tags for all convoy components |
 | global.convoy.tracer_enabled | bool | `false` | Tracing config for all convoy services |
 | global.convoy.tracer_type | string | `"otel"` | Tracing provider type |
 | global.externalDatabase.database | string | `"convoy"` | Database name for the external database |

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -9,4 +9,4 @@ type: application
 version: "3.3.0"
 
 
-appVersion: "v25.2.2"
+appVersion: "v25.9.2"

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -323,6 +323,35 @@ spec:
               value: {{ join "," .Values.env.dispatcher.allow_list | toJson | quote }}
             - name: CONVOY_DISPATCHER_DENY_LIST
               value: {{ join "," .Values.env.dispatcher.deny_list | toJson | quote }}
+
+            {{- if .Values.global.convoy.google_oauth_enabled }}
+            # -- Google OAuth SSO configuration
+            - name: CONVOY_GOOGLE_OAUTH_ENABLED
+              value: {{ .Values.global.convoy.google_oauth_enabled | quote }}
+            - name: CONVOY_GOOGLE_OAUTH_CLIENT_ID
+              value: {{ .Values.global.convoy.google_oauth_client_id | quote }}
+            - name: CONVOY_GOOGLE_OAUTH_REDIRECT_URL
+              value: {{ .Values.global.convoy.google_oauth_redirect_url | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.portal_realm_enabled }}
+            # -- Portal Realm authentication
+            - name: CONVOY_PORTAL_REALM_ENABLED
+              value: {{ .Values.global.convoy.portal_realm_enabled | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.sentry_sample_rate }}
+            # -- Sentry error sampling rate
+            - name: CONVOY_SENTRY_SAMPLE_RATE
+              value: {{ .Values.global.convoy.sentry_sample_rate | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.read_replica_dsn }}
+            # -- Database read replica connection
+            - name: CONVOY_READ_REPLICA_DSN
+              value: {{ .Values.global.convoy.read_replica_dsn | quote }}
+            {{- end }}
+
             {{- with .Values.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -91,7 +91,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: Always
-  tag: v25.2.2
+  tag: v25.9.2
 
 nameOverride: "convoy-agent"
 fullNameOverride: "convoy-agent"

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -21,4 +21,4 @@ version: "1.0.0"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v25.2.2"
+appVersion: "v25.9.2"

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -245,6 +245,34 @@ spec:
             - name: CONVOY_API_VERSION
               value: {{ .Values.env.api_version | quote }}
 
+            {{- if .Values.global.convoy.google_oauth_enabled }}
+            # -- Google OAuth SSO configuration
+            - name: CONVOY_GOOGLE_OAUTH_ENABLED
+              value: {{ .Values.global.convoy.google_oauth_enabled | quote }}
+            - name: CONVOY_GOOGLE_OAUTH_CLIENT_ID
+              value: {{ .Values.global.convoy.google_oauth_client_id | quote }}
+            - name: CONVOY_GOOGLE_OAUTH_REDIRECT_URL
+              value: {{ .Values.global.convoy.google_oauth_redirect_url | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.portal_realm_enabled }}
+            # -- Portal Realm authentication
+            - name: CONVOY_PORTAL_REALM_ENABLED
+              value: {{ .Values.global.convoy.portal_realm_enabled | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.sentry_sample_rate }}
+            # -- Sentry error sampling rate
+            - name: CONVOY_SENTRY_SAMPLE_RATE
+              value: {{ .Values.global.convoy.sentry_sample_rate | quote }}
+            {{- end }}
+
+            {{- if .Values.global.convoy.read_replica_dsn }}
+            # -- Database read replica connection
+            - name: CONVOY_READ_REPLICA_DSN
+              value: {{ .Values.global.convoy.read_replica_dsn | quote }}
+            {{- end }}
+
            {{- if .Values.global.convoy.license_key_secret_name }}
             - name: CONVOY_LICENSE_KEY
               valueFrom:

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -81,6 +81,16 @@ env:
   analytics_enabled: true
   max_retry_seconds: 7200
   license_key: ""
+  # -- Google OAuth configuration
+  google_oauth_enabled: false
+  google_oauth_client_id: ""
+  google_oauth_redirect_url: ""
+  # -- Portal Realm authentication
+  portal_realm_enabled: false
+  # -- Sentry sample rate
+  sentry_sample_rate: 1.0
+  # -- Database read replica DSN
+  read_replica_dsn: ""
 
 # These values serve as defaults for standalone deployment
 # When deployed as a subchart, these can be overridden by parent values:
@@ -89,7 +99,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: Always
-  tag: v25.2.2
+  tag: v25.9.2
 
 nameOverride: "convoy-server"
 fullNameOverride: "convoy-server"

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ global:
     # -- Docker image tags for all convoy components
     image: &image "getconvoy/convoy"
     # -- Docker image tags for all convoy components
-    tag: &tag "v25.6.7"
+    tag: &tag "v25.9.2"
     # -- Logger Level for all convoy components
     log_level: &logLevel "error"
     # -- Convoy Environment
@@ -47,6 +47,18 @@ global:
     cacert_secret_name: ""
     # -- Dispatcher CA Certificate content. If provided, a secret will be created with this content
     cacert_content: ""
+    # -- Enable Google OAuth SSO for user authentication
+    google_oauth_enabled: &googleOAuthEnabled false
+    # -- Google OAuth Client ID from Google Cloud Console
+    google_oauth_client_id: &googleOAuthClientId ""
+    # -- Google OAuth Redirect URL for callback handling
+    google_oauth_redirect_url: &googleOAuthRedirectUrl ""
+    # -- Enable Portal Realm authentication for enhanced security
+    portal_realm_enabled: &portalRealmEnabled false
+    # -- Sentry sample rate for error sampling (0.0 to 1.0)
+    sentry_sample_rate: &sentrySampleRate 1.0
+    # -- Database read replica DSN for improved performance
+    read_replica_dsn: &readReplicaDsn ""
 
   externalDatabase:
     # -- Enable an external database; This will use postgresql chart, Change values if you use an external database


### PR DESCRIPTION
- Updated Chart.yaml version to 3.7.0 and appVersion to 25.9.2
- Added Google OAuth SSO configuration support
- Added Portal Realm authentication support
- Added Sentry sample rate configuration
- Added database read replica DSN support
- Updated image tags to v25.9.2 for server and agent charts
- Added new environment variables for v25.9.2 features
- Updated README with new configuration options