### PR TITLE
add azure blob config to chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Open Source Webhooks Gateway
 
 | Repository | Name | Version |
 |------------|------|---------|
+|  | agent | 3.7.7 |
+|  | server | 3.7.7 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 12.5.6 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 17.11.3 |
 
@@ -44,6 +46,47 @@ helm install convoy convoy/convoy --values values.yaml
 helm install convoy .
 ```
 
+## Object Storage
+
+Convoy supports `s3`, `on_prem`, and `azure_blob` storage backends, selected via
+`server.env.storage.type` (and `agent.env.storage.type`).
+
+### Using a Kubernetes Secret for credentials
+
+For both S3 and Azure Blob you can keep credentials out of your values by referencing
+an existing Kubernetes Secret. Note that **the key name inside the Secret differs by
+backend** — they are intentionally not symmetric:
+
+| Backend | Values field | Required key inside the Secret |
+| --- | --- | --- |
+| S3 | `storage.s3.secret` | `secretKey` |
+| Azure Blob | `storage.azure_blob.secret` | `accountKey` |
+
+Example Azure Blob secret:
+
+```bash
+kubectl create secret generic convoy-azure-storage \
+  --from-literal=accountKey='<your-azure-account-key>'
+```
+
+```yaml
+server:
+  env:
+    storage:
+      enabled: true
+      type: azure_blob
+      azure_blob:
+        account_name: myaccount
+        container_name: convoy-archive
+        secret: convoy-azure-storage   # must contain key "accountKey"
+```
+
+> **Upgrade note (Azure Blob):** Earlier deployments enabled Azure Blob through the
+> `extraEnvs` workaround and typically created their Secret with the key `account_key`.
+> The native `storage.azure_blob.secret` integration reads the key as **`accountKey`**
+> (camelCase). If you are migrating off `extraEnvs`, recreate the Secret with the
+> `accountKey` key, otherwise the account key will not be injected.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -73,14 +116,14 @@ helm install convoy .
 | agent.autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | agent.enabled | bool | `true` | Enable the agent component |
 | agent.env.analytics_enabled | bool | `true` |  |
+| agent.env.auth.jwt.enabled | bool | `true` |  |
+| agent.env.auth.jwt.refresh_secret | string | `"convoy-refresh-secret"` |  |
+| agent.env.auth.jwt.secret | string | `"convoy-secret"` |  |
 | agent.env.consumer_pool_size | int | `100` |  |
 | agent.env.dispatcher.allow_list[0] | string | `"0.0.0.0/0"` |  |
 | agent.env.dispatcher.deny_list[0] | string | `"127.0.0.1/8"` |  |
 | agent.env.dispatcher.deny_list[1] | string | `"169.254.169.254/32"` |  |
 | agent.env.dispatcher.insecure_skip_verify | bool | `false` |  |
-| agent.env.auth.jwt.enabled | bool | `true` |  |
-| agent.env.auth.jwt.refresh_secret | string | `"convoy-refresh-secret"` |  |
-| agent.env.auth.jwt.secret | string | `"convoy-secret"` |  |
 | agent.env.enable_feature_flag | list | `[]` |  |
 | agent.env.enable_profiling | bool | `false` |  |
 | agent.env.environment | string | `"oss"` |  |
@@ -110,11 +153,18 @@ helm install convoy .
 | agent.env.smtp.ssl | bool | `false` |  |
 | agent.env.smtp.url | string | `""` |  |
 | agent.env.smtp.username | string | `""` |  |
+| agent.env.storage.azure_blob.account_key | string | `""` | Ignored in case of secret parameter with non-empty value |
+| agent.env.storage.azure_blob.account_name | string | `""` |  |
+| agent.env.storage.azure_blob.container_name | string | `""` |  |
+| agent.env.storage.azure_blob.endpoint | string | `""` |  |
+| agent.env.storage.azure_blob.prefix | string | `""` |  |
+| agent.env.storage.azure_blob.secret | string | `""` | If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key |
 | agent.env.storage.enabled | bool | `false` |  |
 | agent.env.storage.on_prem.path | string | `""` |  |
 | agent.env.storage.s3.accessKey | string | `""` |  |
 | agent.env.storage.s3.bucket | string | `""` |  |
 | agent.env.storage.s3.endpoint | string | `""` |  |
+| agent.env.storage.s3.prefix | string | `""` |  |
 | agent.env.storage.s3.region | string | `""` |  |
 | agent.env.storage.s3.secret | string | `""` | If this secret parameter is not empty, secretKey value will be ignored. The password in the secret should be in the 'secretKey' key |
 | agent.env.storage.s3.secretKey | string | `""` | Ignored in case of secret parameter with non-empty value |
@@ -176,6 +226,10 @@ helm install convoy .
 | global.externalRedis.port | string | `"6379"` | Port for the external redis |
 | global.externalRedis.scheme | string | `"redis"` | Scheme for the external redis. This can be redis, rediss, redis-socket or redis-sentinel |
 | global.externalRedis.secret | string | `""` | If this secret parameter is not empty, password value will be ignored. The password in the secret should be in the 'password' key |
+| global.externalRedis.sentinelMasterName | string | `"mymaster"` | Redis Sentinel master name (required when scheme is redis-sentinel) |
+| global.externalRedis.sentinelPassword | string | `""` | Redis Sentinel auth password (optional) |
+| global.externalRedis.sentinelSecret | string | `""` | Secret containing sentinel password; key: password. If set, sentinelPassword is ignored |
+| global.externalRedis.sentinelUsername | string | `""` | Redis Sentinel auth username (optional) |
 | global.externalRedis.username | string | `""` | username for the external redis. |
 | global.nativeRedis.enabled | bool | `true` | Enable redis; This will use redis chart, Disable if you use an external redis |
 | global.nativeRedis.host | string | `"redis-master"` | Host for the redis |
@@ -236,6 +290,12 @@ helm install convoy .
 | server.env.retention_policy.policy | string | `"720h"` |  |
 | server.env.root_path | string | `""` | Configure root patth for convoy server e.g. "/convoy" |
 | server.env.sign_up_enabled | bool | `false` |  |
+| server.env.storage.azure_blob.account_key | string | `""` | Ignored in case of secret parameter with non-empty value |
+| server.env.storage.azure_blob.account_name | string | `""` |  |
+| server.env.storage.azure_blob.container_name | string | `""` |  |
+| server.env.storage.azure_blob.endpoint | string | `""` |  |
+| server.env.storage.azure_blob.prefix | string | `""` |  |
+| server.env.storage.azure_blob.secret | string | `""` | If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key |
 | server.env.storage.enabled | bool | `false` |  |
 | server.env.storage.on_prem.path | string | `""` |  |
 | server.env.storage.s3.accessKey | string | `""` |  |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -40,6 +40,47 @@ helm install convoy convoy/convoy --values values.yaml
 helm install convoy .
 ```
 
+## Object Storage
+
+Convoy supports `s3`, `on_prem`, and `azure_blob` storage backends, selected via
+`server.env.storage.type` (and `agent.env.storage.type`).
+
+### Using a Kubernetes Secret for credentials
+
+For both S3 and Azure Blob you can keep credentials out of your values by referencing
+an existing Kubernetes Secret. Note that **the key name inside the Secret differs by
+backend** — they are intentionally not symmetric:
+
+| Backend | Values field | Required key inside the Secret |
+| --- | --- | --- |
+| S3 | `storage.s3.secret` | `secretKey` |
+| Azure Blob | `storage.azure_blob.secret` | `accountKey` |
+
+Example Azure Blob secret:
+
+```bash
+kubectl create secret generic convoy-azure-storage \
+  --from-literal=accountKey='<your-azure-account-key>'
+```
+
+```yaml
+server:
+  env:
+    storage:
+      enabled: true
+      type: azure_blob
+      azure_blob:
+        account_name: myaccount
+        container_name: convoy-archive
+        secret: convoy-azure-storage   # must contain key "accountKey"
+```
+
+> **Upgrade note (Azure Blob):** Earlier deployments enabled Azure Blob through the
+> `extraEnvs` workaround and typically created their Secret with the key `account_key`.
+> The native `storage.azure_blob.secret` integration reads the key as **`accountKey`**
+> (camelCase). If you are migrating off `extraEnvs`, recreate the Secret with the
+> `accountKey` key, otherwise the account key will not be injected.
+
 {{ template "chart.valuesSection" . }}
 
 {{- if not .SkipVersionFooter }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -349,6 +349,27 @@ spec:
             - name: CONVOY_STORAGE_AWS_PREFIX
               value: {{ .Values.env.storage.s3.prefix | quote }}
             {{- end }}
+
+            {{- if eq .Values.env.storage.type "azure_blob" }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_NAME
+              value: {{ .Values.env.storage.azure_blob.account_name | quote }}
+            {{- if and .Values.env.storage.azure_blob.secret (ne .Values.env.storage.azure_blob.secret "") }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.env.storage.azure_blob.secret }}"
+                  key: accountKey
+            {{- else }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              value: {{ .Values.env.storage.azure_blob.account_key | quote }}
+            {{- end }}
+            - name: CONVOY_STORAGE_AZURE_CONTAINER_NAME
+              value: {{ .Values.env.storage.azure_blob.container_name | quote }}
+            - name: CONVOY_STORAGE_AZURE_ENDPOINT
+              value: {{ .Values.env.storage.azure_blob.endpoint | quote }}
+            - name: CONVOY_STORAGE_AZURE_PREFIX
+              value: {{ .Values.env.storage.azure_blob.prefix | quote }}
+            {{- end }}
             {{- end }}
 
             - name: CONVOY_INSTANCE_INGEST_RATE

--- a/charts/agent/templates/rollout.yaml
+++ b/charts/agent/templates/rollout.yaml
@@ -313,6 +313,27 @@ spec:
             - name: CONVOY_STORAGE_AWS_PREFIX
               value: {{ .Values.env.storage.s3.prefix | quote }}
             {{- end }}
+
+            {{- if eq .Values.env.storage.type "azure_blob" }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_NAME
+              value: {{ .Values.env.storage.azure_blob.account_name | quote }}
+            {{- if and .Values.env.storage.azure_blob.secret (ne .Values.env.storage.azure_blob.secret "") }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.env.storage.azure_blob.secret }}"
+                  key: accountKey
+            {{- else }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              value: {{ .Values.env.storage.azure_blob.account_key | quote }}
+            {{- end }}
+            - name: CONVOY_STORAGE_AZURE_CONTAINER_NAME
+              value: {{ .Values.env.storage.azure_blob.container_name | quote }}
+            - name: CONVOY_STORAGE_AZURE_ENDPOINT
+              value: {{ .Values.env.storage.azure_blob.endpoint | quote }}
+            - name: CONVOY_STORAGE_AZURE_PREFIX
+              value: {{ .Values.env.storage.azure_blob.prefix | quote }}
+            {{- end }}
             {{- end }}
 
             - name: CONVOY_INSTANCE_INGEST_RATE

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -135,6 +135,15 @@ env:
       region: ""
       session_token: ""
       endpoint: ""
+    azure_blob:
+      account_name: ""
+      # -- Ignored in case of secret parameter with non-empty value
+      account_key: ""
+      # -- If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key
+      secret: ""
+      container_name: ""
+      endpoint: ""
+      prefix: ""
   consumer_pool_size: 100
   enable_profiling: false
   metrics:

--- a/charts/server/templates/deployment.yaml
+++ b/charts/server/templates/deployment.yaml
@@ -374,7 +374,7 @@ spec:
               value: {{ .Values.env.storage.s3.bucket | quote }}
             - name: CONVOY_STORAGE_AWS_ACCESS_KEY
               value: {{ .Values.env.storage.s3.accessKey | quote }}
-            {{- if ne .Values.env.storage.s3.secret "" }}
+            {{- if and .Values.env.storage.s3.secret (ne .Values.env.storage.s3.secret "") }}
             - name: CONVOY_STORAGE_AWS_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -390,6 +390,29 @@ spec:
               value: {{ .Values.env.storage.s3.session_token | quote }}
             - name: CONVOY_STORAGE_AWS_ENDPOINT
               value: {{ .Values.env.storage.s3.endpoint | quote }}
+            - name: CONVOY_STORAGE_AWS_PREFIX
+              value: {{ .Values.env.storage.s3.prefix | quote }}
+            {{- end }}
+
+            {{- if eq .Values.env.storage.type "azure_blob" }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_NAME
+              value: {{ .Values.env.storage.azure_blob.account_name | quote }}
+            {{- if and .Values.env.storage.azure_blob.secret (ne .Values.env.storage.azure_blob.secret "") }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.env.storage.azure_blob.secret }}"
+                  key: accountKey
+            {{- else }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              value: {{ .Values.env.storage.azure_blob.account_key | quote }}
+            {{- end }}
+            - name: CONVOY_STORAGE_AZURE_CONTAINER_NAME
+              value: {{ .Values.env.storage.azure_blob.container_name | quote }}
+            - name: CONVOY_STORAGE_AZURE_ENDPOINT
+              value: {{ .Values.env.storage.azure_blob.endpoint | quote }}
+            - name: CONVOY_STORAGE_AZURE_PREFIX
+              value: {{ .Values.env.storage.azure_blob.prefix | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/server/templates/rollout.yaml
+++ b/charts/server/templates/rollout.yaml
@@ -338,7 +338,7 @@ spec:
               value: {{ .Values.env.storage.s3.bucket | quote }}
             - name: CONVOY_STORAGE_AWS_ACCESS_KEY
               value: {{ .Values.env.storage.s3.accessKey | quote }}
-            {{- if ne .Values.env.storage.s3.secret "" }}
+            {{- if and .Values.env.storage.s3.secret (ne .Values.env.storage.s3.secret "") }}
             - name: CONVOY_STORAGE_AWS_SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -354,6 +354,29 @@ spec:
               value: {{ .Values.env.storage.s3.session_token | quote }}
             - name: CONVOY_STORAGE_AWS_ENDPOINT
               value: {{ .Values.env.storage.s3.endpoint | quote }}
+            - name: CONVOY_STORAGE_AWS_PREFIX
+              value: {{ .Values.env.storage.s3.prefix | quote }}
+            {{- end }}
+
+            {{- if eq .Values.env.storage.type "azure_blob" }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_NAME
+              value: {{ .Values.env.storage.azure_blob.account_name | quote }}
+            {{- if and .Values.env.storage.azure_blob.secret (ne .Values.env.storage.azure_blob.secret "") }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.env.storage.azure_blob.secret }}"
+                  key: accountKey
+            {{- else }}
+            - name: CONVOY_STORAGE_AZURE_ACCOUNT_KEY
+              value: {{ .Values.env.storage.azure_blob.account_key | quote }}
+            {{- end }}
+            - name: CONVOY_STORAGE_AZURE_CONTAINER_NAME
+              value: {{ .Values.env.storage.azure_blob.container_name | quote }}
+            - name: CONVOY_STORAGE_AZURE_ENDPOINT
+              value: {{ .Values.env.storage.azure_blob.endpoint | quote }}
+            - name: CONVOY_STORAGE_AZURE_PREFIX
+              value: {{ .Values.env.storage.azure_blob.prefix | quote }}
             {{- end }}
             {{- end }}
 

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -116,6 +116,15 @@ env:
       region: ""
       session_token: ""
       endpoint: ""
+    azure_blob:
+      account_name: ""
+      # -- Ignored in case of secret parameter with non-empty value
+      account_key: ""
+      # -- If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key
+      secret: ""
+      container_name: ""
+      endpoint: ""
+      prefix: ""
   api_version: ""
   pyroscope:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -239,6 +239,7 @@ agent:
         path: ""
       s3:
         bucket: ""
+        prefix: ""
         accessKey: ""
         # -- Ignored in case of secret parameter with non-empty value
         secretKey: ""
@@ -247,6 +248,15 @@ agent:
         region: ""
         session_token: ""
         endpoint: ""
+      azure_blob:
+        account_name: ""
+        # -- Ignored in case of secret parameter with non-empty value
+        account_key: ""
+        # -- If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key
+        secret: ""
+        container_name: ""
+        endpoint: ""
+        prefix: ""
     consumer_pool_size: 100
     enable_profiling: false
     metrics:
@@ -387,6 +397,15 @@ server:
         region: ""
         session_token: ""
         endpoint: ""
+      azure_blob:
+        account_name: ""
+        # -- Ignored in case of secret parameter with non-empty value
+        account_key: ""
+        # -- If this secret parameter is not empty, account_key value will be ignored. The account key should be in the 'accountKey' key
+        secret: ""
+        container_name: ""
+        endpoint: ""
+        prefix: ""
     api_version: *apiVersion
     analytics:
       enabled: true


### PR DESCRIPTION
```
change add azure blob config to chart
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cloud storage credentials are injected at deploy time; Azure adopters must use Secret key `accountKey` or upgrades from `extraEnvs`/`account_key` can fail silently on missing credentials.
> 
> **Overview**
> Adds first-class **Azure Blob** object storage to the Convoy Helm chart for **server** and **agent** (Deployment and Rollout templates), driven by `storage.type: azure_blob` and new `storage.azure_blob.*` values that map to `CONVOY_STORAGE_AZURE_*` environment variables.
> 
> Account keys can be set inline or via an existing Secret (`storage.azure_blob.secret`), with the Secret key **`accountKey`** (documented separately from S3’s `secretKey`). README / `README.md.gotmpl` add an **Object Storage** section with examples and an **upgrade note** for teams moving off `extraEnvs` who may still have `account_key` in their Secret.
> 
> **S3** wiring is tightened on the server side: optional `storage.s3.prefix` is emitted as `CONVOY_STORAGE_AWS_PREFIX`, and the S3 secret reference guard matches the agent pattern (`and` + non-empty check). Default `values.yaml` and subchart values gain matching `azure_blob` (and agent `s3.prefix`) blocks; generated README values table reflects the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67691390d0adada715903a83914e0212b83823a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->