### PR TITLE
fix(agent): use smtp.reply_to for CONVOY_SMTP_REPLY_TO (was smtp.from)

### DIFF
--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -285,7 +285,7 @@ spec:
             - name: CONVOY_SMTP_PORT
               value: {{ .Values.env.smtp.port | quote }}
             - name: CONVOY_SMTP_REPLY_TO
-              value: {{ .Values.env.smtp.from | quote }}
+              value: {{ .Values.env.smtp.reply_to | quote }}
             - name: CONVOY_SMTP_PROVIDER
               value: {{ .Values.env.smtp.provider | quote }}
             - name: CONVOY_SMTP_SSL

--- a/charts/agent/templates/rollout.yaml
+++ b/charts/agent/templates/rollout.yaml
@@ -249,7 +249,7 @@ spec:
             - name: CONVOY_SMTP_PORT
               value: {{ .Values.env.smtp.port | quote }}
             - name: CONVOY_SMTP_REPLY_TO
-              value: {{ .Values.env.smtp.from | quote }}
+              value: {{ .Values.env.smtp.reply_to | quote }}
             - name: CONVOY_SMTP_PROVIDER
               value: {{ .Values.env.smtp.provider | quote }}
             - name: CONVOY_SMTP_SSL


### PR DESCRIPTION
The agent deployment and rollout templates set CONVOY_SMTP_REPLY_TO from
.Values.env.smtp.from, so the reply-to address always matched the from
address and the existing smtp.reply_to value was silently ignored. The app
(config.go) treats From and ReplyTo as independent fields. Point the env var
at .Values.env.smtp.reply_to in both charts/agent templates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line Helm env mapping fix with no auth or data-path changes; behavior only shifts when reply_to differs from from.
> 
> **Overview**
> Fixes a wiring bug in the **agent** Helm chart so SMTP reply-to matches chart values and app config.
> 
> When SMTP is enabled, **`CONVOY_SMTP_REPLY_TO`** in both `deployment.yaml` and `rollout.yaml` now comes from **`.Values.env.smtp.reply_to`** instead of **`.Values.env.smtp.from`**. Previously reply-to always mirrored the from address and **`smtp.reply_to`** had no effect on deployed pods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883d55e4c06d3c390b5048e8ba818061c872b61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->