### PR TITLE
chore: prepare release v3.7.8

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 17.11.3
 - name: agent
   repository: ""
-  version: 3.7.7
+  version: 3.7.8
 - name: server
   repository: ""
-  version: 3.7.7
-digest: sha256:b4f07cde63f5a8f23f7f8ba0c1c3fceeb01558a67e2ee067382854ad4553b0e1
-generated: "2026-05-28T21:06:56.373195+01:00"
+  version: 3.7.8
+digest: sha256:c0a25bbd6d0b354695957006b7016e837828c5ec7595391c2368a8c494c18d38
+generated: "2026-07-14T21:30:04.516488+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "3.7.7"
+version: "3.7.8"
 appVersion: "v26.3.7"
 keywords:
   - Webhooks
@@ -13,6 +13,12 @@ maintainers:
   - name: Convoy Engineering Team
     email: engineering@getconvoy.io
     url: https://getconvoy.io
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Azure Blob Storage backend support for object storage (server and agent)
+    - kind: fixed
+      description: SMTP reply-to address now uses env.smtp.reply_to instead of env.smtp.from
 dependencies:
   - name: postgresql
     version: 12.5.6
@@ -26,11 +32,11 @@ dependencies:
 
   # Vendored subcharts under charts/agent and charts/server (see charts/ directory).
   - name: agent
-    version: 3.7.7
+    version: 3.7.8
     repository: ""
     condition: agent.enabled
 
   - name: server
-    version: 3.7.7
+    version: 3.7.8
     repository: ""
     condition: server.enabled

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # convoy
 
-![Version: 3.7.7](https://img.shields.io/badge/Version-3.7.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.3.7](https://img.shields.io/badge/AppVersion-v26.3.7-informational?style=flat-square)
+![Version: 3.7.8](https://img.shields.io/badge/Version-3.7.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.3.7](https://img.shields.io/badge/AppVersion-v26.3.7-informational?style=flat-square)
 
 Open Source Webhooks Gateway
 
@@ -14,8 +14,8 @@ Open Source Webhooks Gateway
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | agent | 3.7.7 |
-|  | server | 3.7.7 |
+|  | agent | 3.7.8 |
+|  | server | 3.7.8 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 12.5.6 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 17.11.3 |
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent
 description: Convoy Agent Chart
 type: application
-version: "3.7.7"
+version: "3.7.8"
 appVersion: "v26.3.7"
 maintainers:
   - name: Convoy Engineering Team

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.7.7"
+version: "3.7.8"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Bump chart to 3.7.8 (appVersion unchanged at v26.3.7).

- added: Azure Blob Storage backend support (server and agent)
- fixed: SMTP reply-to now uses env.smtp.reply_to instead of env.smtp.from

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is chart versioning and release metadata only; no template or values changes in this PR.
> 
> **Overview**
> **Release v3.7.8** bumps the umbrella `convoy` chart and vendored **agent** / **server** subcharts from **3.7.7** to **3.7.8**, with **`appVersion` unchanged** at `v26.3.7`. **`Chart.lock`** is regenerated (new digest/timestamp) so dependency versions align.
> 
> New **`artifacthub.io/changes`** on the parent chart document what ships in this release: **Azure Blob Storage** object-storage support for server and agent, and an **SMTP fix** so reply-to uses `env.smtp.reply_to` instead of `env.smtp.from`. **README** version badges and the agent/server requirement table are updated to **3.7.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1d3796092de00f066529b5d76674d372844f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->