### PR TITLE
chore: prepare release v3.7.9

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 17.11.3
 - name: agent
   repository: ""
-  version: 3.7.8
+  version: 3.7.9
 - name: server
   repository: ""
-  version: 3.7.8
-digest: sha256:c0a25bbd6d0b354695957006b7016e837828c5ec7595391c2368a8c494c18d38
-generated: "2026-07-14T21:30:04.516488+01:00"
+  version: 3.7.9
+digest: sha256:5860e556b3603032f42ab8edc77e40f1b0a3a84d095ee16e3c69d8182d2218f9
+generated: "2026-07-20T13:11:07.604602+01:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: convoy
 description: Open Source Webhooks Gateway
 type: application
 version: "3.7.9"
-appVersion: "v26.6.5"
+appVersion: "v26.6.6"
 keywords:
   - Webhooks
   - Kubernetes
@@ -16,7 +16,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump default Convoy image to v26.6.5
+      description: Bump default Convoy image to v26.6.6
 dependencies:
   - name: postgresql
     version: 12.5.6

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: convoy
 description: Open Source Webhooks Gateway
 type: application
-version: "3.7.8"
-appVersion: "v26.3.7"
+version: "3.7.9"
+appVersion: "v26.6.5"
 keywords:
   - Webhooks
   - Kubernetes
@@ -15,10 +15,8 @@ maintainers:
     url: https://getconvoy.io
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Azure Blob Storage backend support for object storage (server and agent)
-    - kind: fixed
-      description: SMTP reply-to address now uses env.smtp.reply_to instead of env.smtp.from
+    - kind: changed
+      description: Bump default Convoy image to v26.6.5
 dependencies:
   - name: postgresql
     version: 12.5.6
@@ -32,11 +30,11 @@ dependencies:
 
   # Vendored subcharts under charts/agent and charts/server (see charts/ directory).
   - name: agent
-    version: 3.7.8
+    version: 3.7.9
     repository: ""
     condition: agent.enabled
 
   - name: server
-    version: 3.7.8
+    version: 3.7.9
     repository: ""
     condition: server.enabled

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # convoy
 
-![Version: 3.7.9](https://img.shields.io/badge/Version-3.7.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.6.5](https://img.shields.io/badge/AppVersion-v26.6.5-informational?style=flat-square)
+![Version: 3.7.9](https://img.shields.io/badge/Version-3.7.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.6.6](https://img.shields.io/badge/AppVersion-v26.6.6-informational?style=flat-square)
 
 Open Source Webhooks Gateway
 
@@ -205,7 +205,7 @@ server:
 | global.convoy.sentry_dsn | string | `""` | Sentry DSN |
 | global.convoy.sentry_environment | string | `"oss"` | Sentry environment |
 | global.convoy.sentry_sample_rate | float | `1` | Sentry sample rate for error sampling (0.0 to 1.0) |
-| global.convoy.tag | string | `"v26.6.5"` | Docker image tags for all convoy components |
+| global.convoy.tag | string | `"v26.6.6"` | Docker image tags for all convoy components |
 | global.convoy.tracer_enabled | bool | `false` | Tracing config for all convoy services |
 | global.convoy.tracer_type | string | `"otel"` | Tracing provider type |
 | global.externalDatabase.database | string | `"convoy"` | Database name for the external database |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # convoy
 
-![Version: 3.7.8](https://img.shields.io/badge/Version-3.7.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.3.7](https://img.shields.io/badge/AppVersion-v26.3.7-informational?style=flat-square)
+![Version: 3.7.9](https://img.shields.io/badge/Version-3.7.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v26.6.5](https://img.shields.io/badge/AppVersion-v26.6.5-informational?style=flat-square)
 
 Open Source Webhooks Gateway
 
@@ -14,8 +14,8 @@ Open Source Webhooks Gateway
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | agent | 3.7.8 |
-|  | server | 3.7.8 |
+|  | agent | 3.7.9 |
+|  | server | 3.7.9 |
 | oci://registry-1.docker.io/bitnamicharts | postgresql | 12.5.6 |
 | oci://registry-1.docker.io/bitnamicharts | redis | 17.11.3 |
 
@@ -205,7 +205,7 @@ server:
 | global.convoy.sentry_dsn | string | `""` | Sentry DSN |
 | global.convoy.sentry_environment | string | `"oss"` | Sentry environment |
 | global.convoy.sentry_sample_rate | float | `1` | Sentry sample rate for error sampling (0.0 to 1.0) |
-| global.convoy.tag | string | `"v26.3.7"` | Docker image tags for all convoy components |
+| global.convoy.tag | string | `"v26.6.5"` | Docker image tags for all convoy components |
 | global.convoy.tracer_enabled | bool | `false` | Tracing config for all convoy services |
 | global.convoy.tracer_type | string | `"otel"` | Tracing provider type |
 | global.externalDatabase.database | string | `"convoy"` | Database name for the external database |

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agent
 description: Convoy Agent Chart
 type: application
-version: "3.7.8"
-appVersion: "v26.3.7"
+version: "3.7.9"
+appVersion: "v26.6.5"
 maintainers:
   - name: Convoy Engineering Team
     email: engineering@getconvoy.io

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -3,7 +3,7 @@ name: agent
 description: Convoy Agent Chart
 type: application
 version: "3.7.9"
-appVersion: "v26.6.5"
+appVersion: "v26.6.6"
 maintainers:
   - name: Convoy Engineering Team
     email: engineering@getconvoy.io

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -167,7 +167,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: IfNotPresent
-  tag: v26.3.7
+  tag: v26.6.5
 
 nameOverride: "convoy-agent"
 fullNameOverride: "convoy-agent"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -167,7 +167,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: IfNotPresent
-  tag: v26.6.5
+  tag: v26.6.6
 
 nameOverride: "convoy-agent"
 fullNameOverride: "convoy-agent"

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -21,7 +21,7 @@ version: "3.7.9"
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v26.6.5"
+appVersion: "v26.6.6"
 
 maintainers:
   - name: Convoy Engineering Team

--- a/charts/server/Chart.yaml
+++ b/charts/server/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "3.7.8"
+version: "3.7.9"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v26.3.7"
+appVersion: "v26.6.5"
 
 maintainers:
   - name: Convoy Engineering Team

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -166,7 +166,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: Always
-  tag: v26.3.7
+  tag: v26.6.5
 
 nameOverride: "convoy-server"
 fullNameOverride: "convoy-server"

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -166,7 +166,7 @@ env:
 image:
   repository: getconvoy/convoy
   pullPolicy: Always
-  tag: v26.6.5
+  tag: v26.6.6
 
 nameOverride: "convoy-server"
 fullNameOverride: "convoy-server"

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ global:
     # -- Docker image tags for all convoy components
     image: &image "getconvoy/convoy"
     # -- Docker image tags for all convoy components
-    tag: &tag "v26.3.7"
+    tag: &tag "v26.6.5"
     # -- Logger Level for all convoy components
     log_level: &logLevel "error"
     # -- Convoy Environment

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@ global:
     # -- Docker image tags for all convoy components
     image: &image "getconvoy/convoy"
     # -- Docker image tags for all convoy components
-    tag: &tag "v26.6.5"
+    tag: &tag "v26.6.6"
     # -- Logger Level for all convoy components
     log_level: &logLevel "error"
     # -- Convoy Environment


### PR DESCRIPTION
## Summary
- Bump chart to 3.7.9 and default Convoy image tag to v26.6.6 (appVersion v26.3.7 -> v26.6.6)
- Applied across root chart, vendored agent/server subcharts, values defaults, Chart.lock, and README badges/table
- v26.6.6 carries the SSO admin portal auth fix plus the follow-up security hardening (SSO redirect validation, fail-closed slug auth, endpoint RBAC), so fresh installs off the chart default get the fully patched image

## Test plan
- [x] `helm dependency update` regenerates Chart.lock cleanly
- [x] `helm lint` passes
- [x] `helm template` renders agent/server deployments with `getconvoy/convoy:v26.6.6`
- [x] Image `getconvoy/convoy:v26.6.6` published on Docker Hub (amd64 + arm64)